### PR TITLE
Improve wide output format

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,7 +226,28 @@ View exported to view.yaml
 | `--api-url` | | Override API URL from profile |
 | `--auth-token` | | Override auth token from profile |
 | `--dataset` | `-d` | Specify dataset to operate on |
-| `--output` | `-o` | Output format: `table`, `json`, `yaml` |
+| `--output` | `-o` | Output format: `table`, `wide`, `json`, `yaml` |
+
+### Output Formats
+
+The `list` commands support four output formats:
+
+- **`table`** (default): Compact view with essential columns (name and ID)
+- **`wide`**: Similar to `table`, with additional columns (dataset and origin)
+- **`json`**: Full resource data in JSON format
+- **`yaml`**: Full resource data in YAML format
+
+```bash
+$ dash0 dashboards list
+NAME                                      ID
+Production Overview                       a1b2c3d4-5678-90ab-cdef-1234567890ab
+
+$ dash0 dashboards list -o wide
+NAME                                      ID                                    DATASET          ORIGIN
+Production Overview                       a1b2c3d4-5678-90ab-cdef-1234567890ab  default          gitops/prod
+```
+
+The `wide` format includes the `DATASET` column even though `dash0` operates commands on a single dataset at a time. This makes it easier to merge and compare outputs from commands run against different datasets.
 
 ### Shell Completions
 

--- a/internal/checkrules/list.go
+++ b/internal/checkrules/list.go
@@ -62,11 +62,11 @@ func runList(ctx context.Context, flags *resource.ListFlags) error {
 	case output.FormatJSON, output.FormatYAML:
 		return formatter.Print(rules)
 	default:
-		return printCheckRuleTable(formatter, rules)
+		return printCheckRuleTable(formatter, rules, format)
 	}
 }
 
-func printCheckRuleTable(f *output.Formatter, rules []*dash0.PrometheusAlertRuleApiListItem) error {
+func printCheckRuleTable(f *output.Formatter, rules []*dash0.PrometheusAlertRuleApiListItem, format output.Format) error {
 	columns := []output.Column{
 		{Header: "NAME", Width: 40, Value: func(item interface{}) string {
 			r := item.(*dash0.PrometheusAlertRuleApiListItem)
@@ -79,6 +79,22 @@ func printCheckRuleTable(f *output.Formatter, rules []*dash0.PrometheusAlertRule
 			r := item.(*dash0.PrometheusAlertRuleApiListItem)
 			return r.Id
 		}},
+	}
+
+	if format == output.FormatWide {
+		columns = append(columns,
+			output.Column{Header: "DATASET", Width: 15, Value: func(item interface{}) string {
+				r := item.(*dash0.PrometheusAlertRuleApiListItem)
+				return string(r.Dataset)
+			}},
+			output.Column{Header: "ORIGIN", Width: 30, Value: func(item interface{}) string {
+				r := item.(*dash0.PrometheusAlertRuleApiListItem)
+				if r.Origin != nil {
+					return *r.Origin
+				}
+				return ""
+			}},
+		)
 	}
 
 	data := make([]interface{}, len(rules))

--- a/internal/dashboards/list.go
+++ b/internal/dashboards/list.go
@@ -33,6 +33,8 @@ func newListCmd() *cobra.Command {
 type dashboardListItem struct {
 	Id          string
 	DisplayName string
+	Dataset     string
+	Origin      *string
 }
 
 func runList(ctx context.Context, flags *resource.ListFlags) error {
@@ -77,9 +79,11 @@ func runList(ctx context.Context, flags *resource.ListFlags) error {
 			dashboards = append(dashboards, dashboardListItem{
 				Id:          item.Id,
 				DisplayName: displayName,
+				Dataset:     item.Dataset,
+				Origin:      item.Origin,
 			})
 		}
-		return printDashboardTable(formatter, dashboards)
+		return printDashboardTable(formatter, dashboards, format)
 	}
 }
 
@@ -111,7 +115,7 @@ func extractDisplayName(dashboard *dash0.DashboardDefinition) string {
 	return name
 }
 
-func printDashboardTable(f *output.Formatter, dashboards []dashboardListItem) error {
+func printDashboardTable(f *output.Formatter, dashboards []dashboardListItem, format output.Format) error {
 	columns := []output.Column{
 		{Header: "NAME", Width: 40, Value: func(item interface{}) string {
 			d := item.(dashboardListItem)
@@ -121,6 +125,22 @@ func printDashboardTable(f *output.Formatter, dashboards []dashboardListItem) er
 			d := item.(dashboardListItem)
 			return d.Id
 		}},
+	}
+
+	if format == output.FormatWide {
+		columns = append(columns,
+			output.Column{Header: "DATASET", Width: 15, Value: func(item interface{}) string {
+				d := item.(dashboardListItem)
+				return d.Dataset
+			}},
+			output.Column{Header: "ORIGIN", Width: 30, Value: func(item interface{}) string {
+				d := item.(dashboardListItem)
+				if d.Origin != nil {
+					return *d.Origin
+				}
+				return ""
+			}},
+		)
 	}
 
 	// Convert to []interface{}

--- a/internal/syntheticchecks/list.go
+++ b/internal/syntheticchecks/list.go
@@ -62,11 +62,11 @@ func runList(ctx context.Context, flags *resource.ListFlags) error {
 	case output.FormatJSON, output.FormatYAML:
 		return formatter.Print(checks)
 	default:
-		return printSyntheticCheckTable(formatter, checks)
+		return printSyntheticCheckTable(formatter, checks, format)
 	}
 }
 
-func printSyntheticCheckTable(f *output.Formatter, checks []*dash0.SyntheticChecksApiListItem) error {
+func printSyntheticCheckTable(f *output.Formatter, checks []*dash0.SyntheticChecksApiListItem, format output.Format) error {
 	columns := []output.Column{
 		{Header: "NAME", Width: 40, Value: func(item interface{}) string {
 			c := item.(*dash0.SyntheticChecksApiListItem)
@@ -79,6 +79,22 @@ func printSyntheticCheckTable(f *output.Formatter, checks []*dash0.SyntheticChec
 			c := item.(*dash0.SyntheticChecksApiListItem)
 			return c.Id
 		}},
+	}
+
+	if format == output.FormatWide {
+		columns = append(columns,
+			output.Column{Header: "DATASET", Width: 15, Value: func(item interface{}) string {
+				c := item.(*dash0.SyntheticChecksApiListItem)
+				return c.Dataset
+			}},
+			output.Column{Header: "ORIGIN", Width: 30, Value: func(item interface{}) string {
+				c := item.(*dash0.SyntheticChecksApiListItem)
+				if c.Origin != nil {
+					return *c.Origin
+				}
+				return ""
+			}},
+		)
 	}
 
 	data := make([]interface{}, len(checks))

--- a/internal/views/list.go
+++ b/internal/views/list.go
@@ -62,11 +62,11 @@ func runList(ctx context.Context, flags *resource.ListFlags) error {
 	case output.FormatJSON, output.FormatYAML:
 		return formatter.Print(views)
 	default:
-		return printViewTable(formatter, views)
+		return printViewTable(formatter, views, format)
 	}
 }
 
-func printViewTable(f *output.Formatter, views []*dash0.ViewApiListItem) error {
+func printViewTable(f *output.Formatter, views []*dash0.ViewApiListItem, format output.Format) error {
 	columns := []output.Column{
 		{Header: "NAME", Width: 40, Value: func(item interface{}) string {
 			v := item.(*dash0.ViewApiListItem)
@@ -79,6 +79,22 @@ func printViewTable(f *output.Formatter, views []*dash0.ViewApiListItem) error {
 			v := item.(*dash0.ViewApiListItem)
 			return v.Id
 		}},
+	}
+
+	if format == output.FormatWide {
+		columns = append(columns,
+			output.Column{Header: "DATASET", Width: 15, Value: func(item interface{}) string {
+				v := item.(*dash0.ViewApiListItem)
+				return v.Dataset
+			}},
+			output.Column{Header: "ORIGIN", Width: 30, Value: func(item interface{}) string {
+				v := item.(*dash0.ViewApiListItem)
+				if v.Origin != nil {
+					return *v.Origin
+				}
+				return ""
+			}},
+		)
 	}
 
 	data := make([]interface{}, len(views))


### PR DESCRIPTION
Add `dataset` and `origin` to the output of `dash0 <asset-type> list -o wide`.