### PR TITLE
Prep CHANGELOG.md for the introduction of .chloggen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+
+<!-- next version -->


### PR DESCRIPTION
In preparation of `.chloggen`, we need to create the template of `CHANGELOG.md` before we add the CI/CD support (see [this GH Action failure](https://github.com/dash0hq/dash0-cli/actions/runs/21523190300/job/62019771018?pr=6))