### PR TITLE
chore: fix release process

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -15,7 +15,7 @@ concurrency:
 jobs:
   changelog:
     runs-on: ubuntu-latest
-    if: ${{ github.actor != 'dependabot[bot]' && !contains(github.event.pull_request.labels.*.name, 'dependencies') && !contains(github.event.pull_request.labels.*.name, 'Skip Changelog') && !startsWith(github.event.pull_request.title, 'chore') }}
+    if: ${{ github.actor != 'dependabot[bot]' && !contains(github.event.pull_request.labels.*.name, 'dependencies') && !contains(github.event.pull_request.labels.*.name, 'Skip Changelog') && !startsWith(github.event.pull_request.title, 'chore:') }}
     env:
       PR_HEAD: ${{ github.event.pull_request.head.sha }}
 

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -1,0 +1,91 @@
+name: Prepare Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version number (without v prefix, e.g., 1.0.0)'
+        required: true
+        type: string
+
+jobs:
+  prepare:
+    name: Prepare and Tag Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+
+      - name: Validate version format
+        run: |
+          VERSION="${{ inputs.version }}"
+          if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?$ ]]; then
+            echo "Error: Invalid version format '$VERSION'"
+            echo "Expected: MAJOR.MINOR.PATCH (e.g., 1.0.0) or MAJOR.MINOR.PATCH-PRERELEASE (e.g., 1.0.0-rc.1)"
+            echo "Note: Do not include the 'v' prefix"
+            exit 1
+          fi
+          if [[ "$VERSION" =~ ^v ]]; then
+            echo "Error: Version should not start with 'v' prefix"
+            echo "Use '${{ inputs.version }}' instead of 'v${{ inputs.version }}'"
+            exit 1
+          fi
+          echo "Version format valid: $VERSION"
+
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token }}
+
+      - name: Verify tag does not exist
+        run: |
+          if git ls-remote --tags origin | grep -q "refs/tags/v${{ inputs.version }}$"; then
+            echo "Error: Tag v${{ inputs.version }} already exists"
+            exit 1
+          fi
+          echo "Tag v${{ inputs.version }} is available"
+
+      - name: Set up Go
+        uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5
+        with:
+          go-version: '1.24'
+
+      - name: Validate changelog entries exist
+        run: |
+          ENTRY_COUNT=$(find .chloggen -name "*.yaml" ! -name "config.yaml" ! -name "TEMPLATE.yaml" | wc -l)
+          if [ "$ENTRY_COUNT" -eq 0 ]; then
+            echo "Error: No changelog entries found in .chloggen/"
+            exit 1
+          fi
+          echo "Found $ENTRY_COUNT changelog entries"
+
+      - name: Update changelog
+        run: make chlog-update VERSION=${{ inputs.version }}
+
+      - name: Commit and push changelog
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add CHANGELOG.md
+          git rm -f .chloggen/*.yaml --ignore-unmatch 2>/dev/null || true
+          git checkout -- .chloggen/config.yaml .chloggen/TEMPLATE.yaml 2>/dev/null || true
+          git commit -m "chore: update changelog for v${{ inputs.version }}"
+          git push origin main
+
+      - name: Create and push tag
+        run: |
+          git tag v${{ inputs.version }}
+          git push origin v${{ inputs.version }}
+
+      - name: Summary
+        run: |
+          echo "## Release v${{ inputs.version }} prepared successfully!" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "The release workflow has been triggered automatically." >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "View the release progress: ${{ github.server_url }}/${{ github.repository }}/actions/workflows/release.yml" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,34 +32,9 @@ jobs:
           fetch-depth: 0
 
       - name: Set up Go
-        uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 #v5
+        uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5
         with:
           go-version: '1.24'
-
-      - name: Update changelog
-        run: |
-          VERSION=${GITHUB_REF_NAME#v}
-          make chlog-update VERSION=$VERSION
-
-      - name: Extract release notes
-        run: |
-          # Extract the section for this version from CHANGELOG.md
-          VERSION=${GITHUB_REF_NAME#v}
-          awk "/^## $VERSION/,/^## [0-9]/" CHANGELOG.md | head -n -1 > release-notes.md
-          # If extraction failed, use a default message
-          if [ ! -s release-notes.md ]; then
-            echo "Release $VERSION" > release-notes.md
-          fi
-          cat release-notes.md
-
-      - name: Commit updated changelog
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add CHANGELOG.md
-          git rm -f .chloggen/*.yaml 2>/dev/null || true
-          git commit -m "chore: update changelog for ${GITHUB_REF_NAME}" || echo "No changes to commit"
-          git push origin HEAD:main
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@90a3faa9d0182683851fbfa97ca1a2cb983bfca3 # v6.2.1

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,3 +64,28 @@ issues: [42]
 subtext: |
   The new `--output json` flag enables scripting and automation workflows.
 ```
+
+## Releasing
+
+Releases are fully automated via GitHub Actions.
+
+### Creating a Release
+
+1. Go to [Actions > Prepare Release](../../actions/workflows/prepare-release.yml)
+2. Click "Run workflow"
+3. Enter the version number (without `v` prefix, e.g., `1.0.0`)
+4. Click "Run workflow"
+
+The workflow automatically:
+1. Updates `CHANGELOG.md` with entries from `.chloggen/`
+2. Removes the processed `.chloggen/*.yaml` files
+3. Commits the changes to `main`
+4. Creates and pushes the version tag
+5. Triggers the Release workflow, which builds and publishes the release
+
+### Version Numbering
+
+Follow [Semantic Versioning](https://semver.org/):
+- **MAJOR**: Breaking changes
+- **MINOR**: New features (backward compatible)
+- **PATCH**: Bug fixes (backward compatible)


### PR DESCRIPTION
Update the release process to rely on the [Dash0 CLI Release Bot](https://github.com/organizations/dash0hq/settings/apps/dash0-cli-release-bot) to automate the process of prepare the release by updating the changelog.