### PR TITLE
chore: sign Docker images via cosign

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,7 @@ jobs:
     permissions:
       contents: write
       packages: write
+      id-token: write
     steps:
       - name: Log in to the Container registry
         uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
@@ -25,6 +26,9 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
+
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@dc72c7d5c4d10cd6bcb8cf6e3fd625a9e5e537da # v3.7.0
 
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -84,6 +84,15 @@ docker_manifests:
       - "ghcr.io/dash0hq/cli:latest-amd64"
       - "ghcr.io/dash0hq/cli:latest-arm64"
 
+docker_signs:
+  - cmd: cosign
+    artifacts: all
+    output: true
+    args:
+      - "sign"
+      - "${artifact}"
+      - "--yes"
+
 brews:
   - name: dash0
     repository:


### PR DESCRIPTION
After merging, we need to test this with a pre-release (`1.0.1.rc0`)

Closes #12