### PR TITLE
chore: add `config profiles activate` as alias for `config profiles select`

### DIFF
--- a/docs/cli-naming-conventions.md
+++ b/docs/cli-naming-conventions.md
@@ -29,9 +29,10 @@ The `config profiles` command uses:
 | `create`   | `add`    | Create a new profile |
 | `update`   | -        | Update an existing profile |
 | `delete`   | `remove` | Delete a profile |
-| `select`   | -        | Set the active profile |
+| `select`   | `activate` | Set the active profile |
 
 ## Aliases
+- `activate` → `select`
 - `add` → `create`
 - `remove` → `delete`
 - `ls` → `list`

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -123,6 +123,8 @@ $ dash0 config profiles select prod
 Profile 'prod' is now active
 ```
 
+Aliases: `activate`
+
 ### `config profiles delete`
 
 Delete a profile.

--- a/internal/config/config_cmd.go
+++ b/internal/config/config_cmd.go
@@ -427,9 +427,10 @@ func newDeleteProfileCmd() *cobra.Command {
 // newSelectProfileCmd creates a new select profile command
 func newSelectProfileCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "select <name>",
-		Short: "Select a configuration profile",
-		Long:  `Set the active configuration profile`,
+		Use:     "select <name>",
+		Aliases: []string{"activate"},
+		Short:   "Select a configuration profile",
+		Long:    `Set the active configuration profile`,
 		Example: `  # Switch to a different profile
   dash0 config profiles select prod`,
 		Args: cobra.ExactArgs(1),


### PR DESCRIPTION
Closes #55 