### PR TITLE
Fix inconsistency in profile configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ dash0 config profiles create dev \
     --auth-token auth_xxx
 
 dash0 config profiles list
-dash0 config profiles select prod
+dash0 config profiles select dev
 dash0 config show
 ```
 


### PR DESCRIPTION
The profile configuration commands create a profile "dev", and then subsequently select a "prod" profile. Assuming the goal here is to have a consistent set of commands ready to copy and paste I would propose to keep the profile names consistent.