### PR TITLE
feat: add experimental metrics list command for metric name discovery

### DIFF
--- a/.chloggen/metrics-list.yaml
+++ b/.chloggen/metrics-list.yaml
@@ -1,0 +1,14 @@
+change_type: new_component
+
+component: metrics
+
+note: "Add experimental `metrics list` command for metric name discovery"
+
+issues: []
+
+subtext: |
+  Lists available metric names via the Prometheus-compatible label values API.
+  Supports table, wide (with type/unit/description), JSON, and CSV output formats.
+  Includes --filter for substring/regex matching and --from/--to for time range selection.
+
+change_logs: []

--- a/.chloggen/metrics-list.yaml
+++ b/.chloggen/metrics-list.yaml
@@ -4,7 +4,7 @@ component: metrics
 
 note: "Add experimental `metrics list` command for metric name discovery"
 
-issues: []
+issues: [112]
 
 subtext: |
   Lists available metric names via the Prometheus-compatible label values API.

--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,6 @@ completions/
 
 # macOS
 .DS_Store
+
+# Claude Code local settings
+.claude/settings.local.json

--- a/README.md
+++ b/README.md
@@ -346,10 +346,10 @@ dash0 -X traces get <trace-id> --column otel.span.start_time --column otel.span.
 dash0 metrics instant --query 'sum(rate(http_requests_total[5m]))'
 
 # List available metric names (experimental)
-dash0 -X metrics list --filter http_server
+dash0 --experimental metrics list --filter http_server
 
 # Show metric type, unit, and description
-dash0 -X metrics list --filter http_server -o wide
+dash0 --experimental metrics list --filter http_server -o wide
 ```
 
 ### Teams (experimental)

--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ Enable it explicitly with `--agent-mode` or `DASH0_AGENT_MODE=true`, or let it a
 
 When agent mode is active, the CLI:
 
-- **Defaults output to JSON** — all data retrieval commands (`list`, `get`, `query`, `config show`, `metrics instant`) output JSON instead of tables, without needing `-o json`.
+- **Defaults output to JSON** — all data retrieval commands (`list`, `get`, `query`, `config show`, `metrics instant`, `metrics list`) output JSON instead of tables, without needing `-o json`.
 - **Returns `--help` as structured JSON** — flags, subcommands, aliases, and metadata are machine-parseable.
 - **Emits errors as JSON on stderr** — `{"error": "...", "hint": "..."}` instead of colored text.
 - **Skips confirmation prompts** — destructive operations (`delete`, `remove`) proceed without asking, equivalent to `--force`.
@@ -344,6 +344,12 @@ dash0 -X traces get <trace-id> --column otel.span.start_time --column otel.span.
 
 ```bash
 dash0 metrics instant --query 'sum(rate(http_requests_total[5m]))'
+
+# List available metric names (experimental)
+dash0 -X metrics list --filter http_server
+
+# Show metric type, unit, and description
+dash0 -X metrics list --filter http_server -o wide
 ```
 
 ### Teams (experimental)

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -934,7 +934,7 @@ List available metric names from the Dash0 API.
 Discovers metric names via the Prometheus-compatible label values API.
 
 ```bash
-dash0 -X metrics list [flags]
+dash0 --experimental metrics list [flags]
 ```
 
 | Flag | Short | Default | Description |
@@ -961,7 +961,7 @@ Examples:
 
 ```bash
 # List all metric names (last 1 hour)
-$ dash0 -X metrics list
+$ dash0 --experimental metrics list
 NAME
 container_cpu_usage_seconds_total
 http_server_active_requests
@@ -969,26 +969,26 @@ http_server_request_duration_seconds_bucket
 ...
 
 # Filter by substring
-$ dash0 -X metrics list --filter http_server
+$ dash0 --experimental metrics list --filter http_server
 
 # Filter by regex
-$ dash0 -X metrics list --filter "^http_server.*total$"
+$ dash0 --experimental metrics list --filter "^http_server.*total$"
 
 # Show type, unit, and description
-$ dash0 -X metrics list --filter http_server -o wide
+$ dash0 --experimental metrics list --filter http_server -o wide
 NAME                                              TYPE        UNIT        DESCRIPTION
 http_server_active_requests                       gauge       {request}   Number of active HTTP server requests
 http_server_request_duration_seconds_bucket       histogram   s           Duration of HTTP server requests
 ...
 
 # Custom time range
-$ dash0 -X metrics list --from now-6h
+$ dash0 --experimental metrics list --from now-6h
 
 # Limit results
-$ dash0 -X metrics list --limit 20
+$ dash0 --experimental metrics list --limit 20
 
 # Output as JSON (includes metadata)
-$ dash0 -X metrics list --filter http_server -o json
+$ dash0 --experimental metrics list --filter http_server -o json
 [
   {
     "name": "http_server_active_requests",
@@ -1000,7 +1000,7 @@ $ dash0 -X metrics list --filter http_server -o json
 ]
 
 # Output as CSV
-$ dash0 -X metrics list --filter http_server -o csv
+$ dash0 --experimental metrics list --filter http_server -o csv
 ```
 
 Aliases: `ls`

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -928,6 +928,83 @@ Example:
 $ dash0 metrics instant --query 'sum(rate(http_requests_total[5m]))'
 ```
 
+### `metrics list` (experimental)
+
+List available metric names from the Dash0 API.
+Discovers metric names via the Prometheus-compatible label values API.
+
+```bash
+dash0 -X metrics list [flags]
+```
+
+| Flag | Short | Default | Description |
+|------|-------|---------|-------------|
+| `--output` | `-o` | `table` | Output format: `table`, `wide`, `json`, `csv` |
+| `--from` | | `now-1h` | Start of time range |
+| `--to` | | `now` | End of time range |
+| `--filter` | | | Substring or regex filter on metric names |
+| `--limit` | `-l` | 0 (no limit) | Maximum number of results |
+| `--skip-header` | | `false` | Omit the header row from `table`, `wide`, and `csv` output |
+| `--dataset` | | | Dataset override |
+
+The default `table` output shows a single NAME column.
+The `wide` format adds TYPE, UNIT, and DESCRIPTION columns (fetched from the Prometheus metadata API).
+The `json` format outputs an array of objects with name, type, unit, and help fields.
+The `csv` format uses the same columns as `wide`.
+
+Both `--from` and `--to` accept relative expressions like `now-1h` or absolute ISO 8601 timestamps.
+
+The `--filter` flag matches metric names client-side.
+If the value compiles as a regular expression, regex matching is used; otherwise it falls back to case-insensitive substring matching.
+
+Examples:
+
+```bash
+# List all metric names (last 1 hour)
+$ dash0 -X metrics list
+NAME
+container_cpu_usage_seconds_total
+http_server_active_requests
+http_server_request_duration_seconds_bucket
+...
+
+# Filter by substring
+$ dash0 -X metrics list --filter http_server
+
+# Filter by regex
+$ dash0 -X metrics list --filter "^http_server.*total$"
+
+# Show type, unit, and description
+$ dash0 -X metrics list --filter http_server -o wide
+NAME                                              TYPE        UNIT        DESCRIPTION
+http_server_active_requests                       gauge       {request}   Number of active HTTP server requests
+http_server_request_duration_seconds_bucket       histogram   s           Duration of HTTP server requests
+...
+
+# Custom time range
+$ dash0 -X metrics list --from now-6h
+
+# Limit results
+$ dash0 -X metrics list --limit 20
+
+# Output as JSON (includes metadata)
+$ dash0 -X metrics list --filter http_server -o json
+[
+  {
+    "name": "http_server_active_requests",
+    "type": "gauge",
+    "unit": "{request}",
+    "help": "Number of active HTTP server requests"
+  },
+  ...
+]
+
+# Output as CSV
+$ dash0 -X metrics list --filter http_server -o csv
+```
+
+Aliases: `ls`
+
 ## Team management
 
 Teams and members are organizational entities (not "assets").

--- a/internal/metrics/instant_query_cmd.go
+++ b/internal/metrics/instant_query_cmd.go
@@ -40,6 +40,7 @@ func NewMetricsCmd() *cobra.Command {
 
 	// Add subcommands
 	cmd.AddCommand(newInstantQueryCmd())
+	cmd.AddCommand(newListCmd())
 
 	return cmd
 }

--- a/internal/metrics/list_cmd.go
+++ b/internal/metrics/list_cmd.go
@@ -374,6 +374,8 @@ func fetchMetadata(apiUrl, authToken, dataset string) (map[string]MetadataEntry,
 	return result, nil
 }
 
+var httpClient = &http.Client{Timeout: 30 * time.Second}
+
 func doGet(requestURL, authToken string) ([]byte, error) {
 	req, err := http.NewRequest("GET", requestURL, nil)
 	if err != nil {
@@ -382,8 +384,7 @@ func doGet(requestURL, authToken string) ([]byte, error) {
 	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", authToken))
 	req.Header.Set("User-Agent", version.UserAgent())
 
-	client := &http.Client{Timeout: 30 * time.Second}
-	resp, err := client.Do(req)
+	resp, err := httpClient.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("failed to execute HTTP request: %w", err)
 	}

--- a/internal/metrics/list_cmd.go
+++ b/internal/metrics/list_cmd.go
@@ -158,7 +158,7 @@ func newListCmd() *cobra.Command {
 	cmd.Flags().StringVar(&flags.Dataset, "dataset", "", "Dataset name")
 	cmd.Flags().StringVarP(&flags.Output, "output", "o", "", "Output format: table, wide, json, csv (default: table)")
 	cmd.Flags().StringVar(&flags.From, "from", "now-1h", "Start of time range (e.g. now-1h, now-6h, 2024-01-25T10:00:00Z)")
-	cmd.Flags().StringVar(&flags.To, "to", "now", "End of time range (e.g. now, 2024-01-25T11:00:00Z)")
+	cmd.Flags().StringVar(&flags.To, "to", "now", "End of time range (e.g. now, now-1h, 2024-01-25T11:00:00Z)")
 	cmd.Flags().StringVar(&flags.Filter, "filter", "", "Substring or regex filter on metric names")
 	cmd.Flags().IntVarP(&flags.Limit, "limit", "l", 0, "Maximum number of results (0 = no limit)")
 	cmd.Flags().BoolVar(&flags.SkipHeader, "skip-header", false, "Omit the header row from table, wide, and CSV output")

--- a/internal/metrics/list_cmd.go
+++ b/internal/metrics/list_cmd.go
@@ -111,32 +111,32 @@ func newListCmd() *cobra.Command {
 		Short: "[experimental] List available metric names",
 		Long: `List available metric names from Dash0 and display them in various formats.` + internal.CONFIG_HINT,
 		Example: `  # List all metric names (last 1 hour)
-  dash0 -X metrics list
+  dash0 --experimental metrics list
 
   # Filter by substring
-  dash0 -X metrics list --filter http_server
+  dash0 --experimental metrics list --filter http_server
 
   # Filter by regex (any valid Go regexp)
-  dash0 -X metrics list --filter "^http_server.*total$"
+  dash0 --experimental metrics list --filter "^http_server.*total$"
 
   # Show type, unit, and description (wide output)
-  dash0 -X metrics list --filter http_server -o wide
+  dash0 --experimental metrics list --filter http_server -o wide
 
   # Custom time range
-  dash0 -X metrics list --from now-6h
-  dash0 -X metrics list --from now-30m --to now
+  dash0 --experimental metrics list --from now-6h
+  dash0 --experimental metrics list --from now-30m --to now
 
   # Limit results
-  dash0 -X metrics list --limit 20
+  dash0 --experimental metrics list --limit 20
 
   # Output as JSON (includes type, unit, and description)
-  dash0 -X metrics list --filter http_server -o json
+  dash0 --experimental metrics list --filter http_server -o json
 
   # Output as CSV (same columns as wide)
-  dash0 -X metrics list --filter http_server -o csv
+  dash0 --experimental metrics list --filter http_server -o csv
 
   # CSV without header
-  dash0 -X metrics list -o csv --skip-header
+  dash0 --experimental metrics list -o csv --skip-header
 
   The --filter flag tries to compile the value as a regular expression.
   If it is not a valid regexp, it falls back to case-insensitive substring matching.

--- a/internal/metrics/list_cmd.go
+++ b/internal/metrics/list_cmd.go
@@ -109,15 +109,7 @@ func newListCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "list",
 		Short: "[experimental] List available metric names",
-		Long: `List available metric names from the Dash0 API.
-
-Discovers metric names via the Prometheus-compatible label values API.
-The default table output shows only metric names; use -o wide to also
-see type, unit, and description (fetched from the metadata API).
-
-The --filter flag matches metric names by substring or regex. If the
-filter compiles as a regular expression, regex matching is used;
-otherwise it falls back to case-insensitive substring matching.` + internal.CONFIG_HINT,
+		Long: `List available metric names from Dash0 and display them in various formats.` + internal.CONFIG_HINT,
 		Example: `  # List all metric names (last 1 hour)
   dash0 -X metrics list
 

--- a/internal/metrics/list_cmd.go
+++ b/internal/metrics/list_cmd.go
@@ -1,0 +1,433 @@
+package metrics
+
+import (
+	"encoding/csv"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"regexp"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/dash0hq/dash0-cli/internal"
+	"github.com/dash0hq/dash0-cli/internal/agentmode"
+	"github.com/dash0hq/dash0-cli/internal/config"
+	"github.com/dash0hq/dash0-cli/internal/experimental"
+	"github.com/dash0hq/dash0-cli/internal/output"
+	"github.com/dash0hq/dash0-cli/internal/query"
+	"github.com/dash0hq/dash0-cli/internal/version"
+	"github.com/spf13/cobra"
+)
+
+// LabelValuesResponse represents the response from the Prometheus label values API.
+type LabelValuesResponse struct {
+	Status string   `json:"status"`
+	Data   []string `json:"data"`
+	Error  string   `json:"error,omitempty"`
+}
+
+// MetadataResponse represents the response from the Prometheus metadata API.
+type MetadataResponse struct {
+	Status string                       `json:"status"`
+	Data   map[string][]MetadataEntry   `json:"data"`
+	Error  string                       `json:"error,omitempty"`
+}
+
+// MetadataEntry represents a single metadata entry for a metric.
+type MetadataEntry struct {
+	Type string `json:"type"`
+	Help string `json:"help"`
+	Unit string `json:"unit"`
+}
+
+// MetricInfo is the output representation for a metric with its metadata.
+type MetricInfo struct {
+	Name string `json:"name"`
+	Type string `json:"type"`
+	Unit string `json:"unit"`
+	Help string `json:"help"`
+}
+
+type listFlags struct {
+	ApiUrl     string
+	AuthToken  string
+	Dataset    string
+	Output     string
+	From       string
+	To         string
+	Filter     string
+	Limit      int
+	SkipHeader bool
+}
+
+type listFormat string
+
+const (
+	listFormatTable listFormat = "table"
+	listFormatWide  listFormat = "wide"
+	listFormatJSON  listFormat = "json"
+	listFormatCSV   listFormat = "csv"
+)
+
+var listDefaultColumns = []query.ColumnDef{
+	{Key: "name", Header: internal.HEADER_NAME, Width: 0},
+}
+
+var listWideColumns = []query.ColumnDef{
+	{Key: "name", Header: internal.HEADER_NAME, Width: 60},
+	{Key: "type", Header: internal.HEADER_TYPE, Width: 12},
+	{Key: "unit", Header: "UNIT", Width: 16},
+	{Key: "description", Header: "DESCRIPTION", Width: 0},
+}
+
+func parseListFormat(s string) (listFormat, error) {
+	switch strings.ToLower(s) {
+	case "":
+		if agentmode.Enabled {
+			return listFormatJSON, nil
+		}
+		return listFormatTable, nil
+	case "table":
+		return listFormatTable, nil
+	case "wide":
+		return listFormatWide, nil
+	case "json":
+		return listFormatJSON, nil
+	case "csv":
+		return listFormatCSV, nil
+	default:
+		return "", fmt.Errorf("unknown output format: %s (valid formats: table, wide, json, csv)", s)
+	}
+}
+
+func newListCmd() *cobra.Command {
+	flags := &listFlags{}
+
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "[experimental] List available metric names",
+		Long: `List available metric names from the Dash0 API.
+
+Discovers metric names via the Prometheus-compatible label values API.
+The default table output shows only metric names; use -o wide to also
+see type, unit, and description (fetched from the metadata API).
+
+The --filter flag matches metric names by substring or regex. If the
+filter compiles as a regular expression, regex matching is used;
+otherwise it falls back to case-insensitive substring matching.` + internal.CONFIG_HINT,
+		Example: `  # List all metric names (last 1 hour)
+  dash0 -X metrics list
+
+  # Filter by substring
+  dash0 -X metrics list --filter http_server
+
+  # Filter by regex
+  dash0 -X metrics list --filter "^http_server.*total$"
+
+  # Show type, unit, and description
+  dash0 -X metrics list --filter http_server -o wide
+
+  # Custom time range
+  dash0 -X metrics list --from now-6h
+  dash0 -X metrics list --from now-30m --to now
+
+  # Limit results
+  dash0 -X metrics list --limit 20
+
+  # Output as JSON (includes metadata)
+  dash0 -X metrics list --filter http_server -o json
+
+  # Output as CSV (same columns as wide)
+  dash0 -X metrics list --filter http_server -o csv
+
+  # CSV without header
+  dash0 -X metrics list -o csv --skip-header`,
+		Aliases: []string{"ls"},
+		Args:    cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			if err := experimental.RequireExperimental(cmd); err != nil {
+				return err
+			}
+			return runList(cmd, flags)
+		},
+	}
+
+	cmd.Flags().StringVar(&flags.ApiUrl, "api-url", "", "API endpoint URL (overrides active profile)")
+	cmd.Flags().StringVar(&flags.AuthToken, "auth-token", "", "Auth token (overrides active profile)")
+	cmd.Flags().StringVar(&flags.Dataset, "dataset", "", "Dataset name")
+	cmd.Flags().StringVarP(&flags.Output, "output", "o", "", "Output format: table, wide, json, csv (default: table)")
+	cmd.Flags().StringVar(&flags.From, "from", "now-1h", "Start of time range (e.g. now-1h, now-6h, 2024-01-25T10:00:00Z)")
+	cmd.Flags().StringVar(&flags.To, "to", "now", "End of time range (e.g. now, 2024-01-25T11:00:00Z)")
+	cmd.Flags().StringVar(&flags.Filter, "filter", "", "Substring or regex filter on metric names")
+	cmd.Flags().IntVarP(&flags.Limit, "limit", "l", 0, "Maximum number of results (0 = no limit)")
+	cmd.Flags().BoolVar(&flags.SkipHeader, "skip-header", false, "Omit the header row from table, wide, and CSV output")
+
+	return cmd
+}
+
+func runList(_ *cobra.Command, flags *listFlags) error {
+	if err := output.ValidateSkipHeader(flags.SkipHeader, flags.Output); err != nil {
+		return err
+	}
+
+	format, err := parseListFormat(flags.Output)
+	if err != nil {
+		return err
+	}
+
+	cfg, err := config.ResolveConfiguration(flags.ApiUrl, flags.AuthToken)
+	if err != nil {
+		return err
+	}
+	apiUrl := cfg.ApiUrl
+	authToken := cfg.AuthToken
+
+	dataset := flags.Dataset
+	if dataset == "" {
+		dataset = cfg.Dataset
+	}
+
+	startEpoch, err := query.ResolveToEpochSeconds(flags.From)
+	if err != nil {
+		return fmt.Errorf("invalid --from value: %w", err)
+	}
+	endEpoch, err := query.ResolveToEpochSeconds(flags.To)
+	if err != nil {
+		return fmt.Errorf("invalid --to value: %w", err)
+	}
+
+	needsMetadata := format == listFormatWide || format == listFormatJSON || format == listFormatCSV
+
+	if needsMetadata {
+		return runListWithMetadata(apiUrl, authToken, dataset, startEpoch, endEpoch, flags, format)
+	}
+	return runListNamesOnly(apiUrl, authToken, dataset, startEpoch, endEpoch, flags)
+}
+
+func runListNamesOnly(apiUrl, authToken, dataset, startEpoch, endEpoch string, flags *listFlags) error {
+	names, err := fetchLabelValues(apiUrl, authToken, dataset, startEpoch, endEpoch)
+	if err != nil {
+		return err
+	}
+
+	names = filterNames(names, flags.Filter)
+	names = applyLimit(names, flags.Limit)
+
+	if len(names) == 0 {
+		fmt.Fprintln(os.Stderr, "No metrics found.")
+		return nil
+	}
+
+	rows := make([]map[string]string, len(names))
+	for i, name := range names {
+		rows[i] = map[string]string{"name": name}
+	}
+
+	query.RenderTable(os.Stdout, listDefaultColumns, rows, flags.SkipHeader)
+	return nil
+}
+
+func runListWithMetadata(apiUrl, authToken, dataset, startEpoch, endEpoch string, flags *listFlags, format listFormat) error {
+	metadata, err := fetchMetadata(apiUrl, authToken, dataset)
+	if err != nil {
+		return err
+	}
+
+	// Extract and sort metric names from metadata
+	names := make([]string, 0, len(metadata))
+	for name := range metadata {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	names = filterNames(names, flags.Filter)
+	names = applyLimit(names, flags.Limit)
+
+	if len(names) == 0 {
+		fmt.Fprintln(os.Stderr, "No metrics found.")
+		return nil
+	}
+
+	metrics := make([]MetricInfo, len(names))
+	for i, name := range names {
+		entry := metadata[name]
+		metrics[i] = MetricInfo{
+			Name: name,
+			Type: entry.Type,
+			Unit: entry.Unit,
+			Help: entry.Help,
+		}
+	}
+
+	switch format {
+	case listFormatJSON:
+		return renderJSON(metrics)
+	case listFormatCSV:
+		return renderCSV(metrics, flags.SkipHeader)
+	default:
+		return renderWideTable(metrics, flags.SkipHeader)
+	}
+}
+
+func renderJSON(metrics []MetricInfo) error {
+	enc := json.NewEncoder(os.Stdout)
+	enc.SetIndent("", "  ")
+	return enc.Encode(metrics)
+}
+
+func renderWideTable(metrics []MetricInfo, skipHeader bool) error {
+	rows := make([]map[string]string, len(metrics))
+	for i, m := range metrics {
+		rows[i] = map[string]string{
+			"name":        m.Name,
+			"type":        m.Type,
+			"unit":        m.Unit,
+			"description": m.Help,
+		}
+	}
+	query.RenderTable(os.Stdout, listWideColumns, rows, skipHeader)
+	return nil
+}
+
+func renderCSV(metrics []MetricInfo, skipHeader bool) error {
+	w := csv.NewWriter(os.Stdout)
+	if !skipHeader {
+		if err := w.Write([]string{"name", "type", "unit", "description"}); err != nil {
+			return err
+		}
+	}
+	for _, m := range metrics {
+		if err := w.Write([]string{m.Name, m.Type, m.Unit, m.Help}); err != nil {
+			return err
+		}
+	}
+	w.Flush()
+	return w.Error()
+}
+
+func fetchLabelValues(apiUrl, authToken, dataset, startEpoch, endEpoch string) ([]string, error) {
+	u, err := url.Parse(apiUrl)
+	if err != nil {
+		return nil, fmt.Errorf("invalid API URL: %w", err)
+	}
+	u.Path = "/api/prometheus/api/v1/label/__name__/values"
+
+	params := url.Values{}
+	params.Set("start", startEpoch)
+	params.Set("end", endEpoch)
+	if dataset != "" && dataset != "default" {
+		params.Set("dataset", dataset)
+	}
+	u.RawQuery = params.Encode()
+
+	body, err := doGet(u.String(), authToken)
+	if err != nil {
+		return nil, err
+	}
+
+	var resp LabelValuesResponse
+	if err := json.Unmarshal(body, &resp); err != nil {
+		return nil, fmt.Errorf("failed to parse label values response: %w", err)
+	}
+	if resp.Status != "success" {
+		return nil, fmt.Errorf("label values query failed: %s", resp.Error)
+	}
+	return resp.Data, nil
+}
+
+func fetchMetadata(apiUrl, authToken, dataset string) (map[string]MetadataEntry, error) {
+	u, err := url.Parse(apiUrl)
+	if err != nil {
+		return nil, fmt.Errorf("invalid API URL: %w", err)
+	}
+	u.Path = "/api/prometheus/api/v1/metadata"
+
+	params := url.Values{}
+	if dataset != "" && dataset != "default" {
+		params.Set("dataset", dataset)
+	}
+	u.RawQuery = params.Encode()
+
+	body, err := doGet(u.String(), authToken)
+	if err != nil {
+		return nil, err
+	}
+
+	var resp MetadataResponse
+	if err := json.Unmarshal(body, &resp); err != nil {
+		return nil, fmt.Errorf("failed to parse metadata response: %w", err)
+	}
+	if resp.Status != "success" {
+		return nil, fmt.Errorf("metadata query failed: %s", resp.Error)
+	}
+
+	// Flatten: take the first metadata entry for each metric name
+	result := make(map[string]MetadataEntry, len(resp.Data))
+	for name, entries := range resp.Data {
+		if len(entries) > 0 {
+			result[name] = entries[0]
+		}
+	}
+	return result, nil
+}
+
+func doGet(requestURL, authToken string) ([]byte, error) {
+	req, err := http.NewRequest("GET", requestURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create HTTP request: %w", err)
+	}
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", authToken))
+	req.Header.Set("User-Agent", version.UserAgent())
+
+	client := &http.Client{Timeout: 30 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to execute HTTP request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response body: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("API request failed with status %d: %s", resp.StatusCode, string(body))
+	}
+
+	return body, nil
+}
+
+func filterNames(names []string, filter string) []string {
+	if filter == "" {
+		return names
+	}
+
+	re, regexErr := regexp.Compile(filter)
+
+	var result []string
+	for _, name := range names {
+		if regexErr != nil {
+			// Regex didn't compile — fall back to case-insensitive substring match
+			if strings.Contains(strings.ToLower(name), strings.ToLower(filter)) {
+				result = append(result, name)
+			}
+		} else {
+			if re.MatchString(name) {
+				result = append(result, name)
+			}
+		}
+	}
+	return result
+}
+
+func applyLimit(names []string, limit int) []string {
+	if limit > 0 && len(names) > limit {
+		return names[:limit]
+	}
+	return names
+}

--- a/internal/metrics/list_cmd.go
+++ b/internal/metrics/list_cmd.go
@@ -9,7 +9,6 @@ import (
 	"net/url"
 	"os"
 	"regexp"
-	"sort"
 	"strings"
 	"time"
 
@@ -232,17 +231,17 @@ func runListNamesOnly(apiUrl, authToken, dataset, startEpoch, endEpoch string, f
 }
 
 func runListWithMetadata(apiUrl, authToken, dataset, startEpoch, endEpoch string, flags *listFlags, format listFormat) error {
-	metadata, err := fetchMetadata(apiUrl, authToken, dataset)
+	// Use label values API as the authoritative name list (respects time range),
+	// then enrich with metadata. This keeps results consistent across all formats.
+	names, err := fetchLabelValues(apiUrl, authToken, dataset, startEpoch, endEpoch)
 	if err != nil {
 		return err
 	}
 
-	// Extract and sort metric names from metadata
-	names := make([]string, 0, len(metadata))
-	for name := range metadata {
-		names = append(names, name)
+	metadata, err := fetchMetadata(apiUrl, authToken, dataset)
+	if err != nil {
+		return err
 	}
-	sort.Strings(names)
 
 	names = filterNames(names, flags.Filter)
 	names = applyLimit(names, flags.Limit)

--- a/internal/metrics/list_cmd.go
+++ b/internal/metrics/list_cmd.go
@@ -116,10 +116,10 @@ func newListCmd() *cobra.Command {
   # Filter by substring
   dash0 -X metrics list --filter http_server
 
-  # Filter by regex
+  # Filter by regex (any valid Go regexp)
   dash0 -X metrics list --filter "^http_server.*total$"
 
-  # Show type, unit, and description
+  # Show type, unit, and description (wide output)
   dash0 -X metrics list --filter http_server -o wide
 
   # Custom time range
@@ -129,14 +129,20 @@ func newListCmd() *cobra.Command {
   # Limit results
   dash0 -X metrics list --limit 20
 
-  # Output as JSON (includes metadata)
+  # Output as JSON (includes type, unit, and description)
   dash0 -X metrics list --filter http_server -o json
 
   # Output as CSV (same columns as wide)
   dash0 -X metrics list --filter http_server -o csv
 
   # CSV without header
-  dash0 -X metrics list -o csv --skip-header`,
+  dash0 -X metrics list -o csv --skip-header
+
+  The --filter flag tries to compile the value as a regular expression.
+  If it is not a valid regexp, it falls back to case-insensitive substring matching.
+
+  The wide, JSON, and CSV formats include metric type, unit, and description
+  from the Prometheus metadata API.`,
 		Aliases: []string{"ls"},
 		Args:    cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {

--- a/internal/metrics/list_cmd.go
+++ b/internal/metrics/list_cmd.go
@@ -169,12 +169,12 @@ otherwise it falls back to case-insensitive substring matching.` + internal.CONF
 }
 
 func runList(_ *cobra.Command, flags *listFlags) error {
-	if err := output.ValidateSkipHeader(flags.SkipHeader, flags.Output); err != nil {
+	format, err := parseListFormat(flags.Output)
+	if err != nil {
 		return err
 	}
 
-	format, err := parseListFormat(flags.Output)
-	if err != nil {
+	if err := output.ValidateSkipHeader(flags.SkipHeader, flags.Output); err != nil {
 		return err
 	}
 

--- a/internal/metrics/list_cmd.go
+++ b/internal/metrics/list_cmd.go
@@ -410,13 +410,16 @@ func filterNames(names []string, filter string) []string {
 	re, regexErr := regexp.Compile(filter)
 
 	var result []string
-	for _, name := range names {
-		if regexErr != nil {
-			// Regex didn't compile — fall back to case-insensitive substring match
-			if strings.Contains(strings.ToLower(name), strings.ToLower(filter)) {
+	if regexErr != nil {
+		// Regex didn't compile — fall back to case-insensitive substring match
+		filterLower := strings.ToLower(filter)
+		for _, name := range names {
+			if strings.Contains(strings.ToLower(name), filterLower) {
 				result = append(result, name)
 			}
-		} else {
+		}
+	} else {
+		for _, name := range names {
 			if re.MatchString(name) {
 				result = append(result, name)
 			}

--- a/internal/metrics/list_cmd_test.go
+++ b/internal/metrics/list_cmd_test.go
@@ -400,7 +400,7 @@ func TestListSkipHeaderWithJSON(t *testing.T) {
 	assert.Contains(t, err.Error(), "--skip-header is not supported")
 }
 
-func TestListWideMetadataEndpoint(t *testing.T) {
+func TestListWideHitsBothEndpoints(t *testing.T) {
 	var labelValuesHit, metadataHit bool
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
@@ -418,8 +418,8 @@ func TestListWideMetadataEndpoint(t *testing.T) {
 
 	_, _, err := execListCmd(t, "-o", "wide")
 	require.NoError(t, err)
-	assert.False(t, labelValuesHit, "wide format should not hit label values API")
-	assert.True(t, metadataHit, "wide format should hit metadata API")
+	assert.True(t, labelValuesHit, "wide format should hit label values API for time-scoped names")
+	assert.True(t, metadataHit, "wide format should hit metadata API for enrichment")
 }
 
 func TestListTableLabelValuesEndpoint(t *testing.T) {

--- a/internal/metrics/list_cmd_test.go
+++ b/internal/metrics/list_cmd_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/dash0hq/dash0-cli/internal/agentmode"
 	"github.com/dash0hq/dash0-cli/internal/testutil"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
@@ -217,6 +218,40 @@ func TestListTableSkipHeader(t *testing.T) {
 
 	assert.NotContains(t, output, "NAME")
 	assert.Contains(t, output, "http_server_active_requests")
+}
+
+func TestListWideSkipHeader(t *testing.T) {
+	server := newTestServer(t)
+	defer server.Close()
+	setupEnv(t, server.URL)
+
+	_, output, err := execListCmd(t, "-o", "wide", "--skip-header")
+	require.NoError(t, err)
+
+	assert.NotContains(t, output, "NAME")
+	assert.NotContains(t, output, "TYPE")
+	assert.NotContains(t, output, "DESCRIPTION")
+	assert.Contains(t, output, "http_server_active_requests")
+	assert.Contains(t, output, "gauge")
+}
+
+func TestListAgentModeDefaultsToJSON(t *testing.T) {
+	server := newTestServer(t)
+	defer server.Close()
+	setupEnv(t, server.URL)
+
+	// Enable agent mode and restore after test
+	prev := agentmode.Enabled
+	agentmode.Enabled = true
+	defer func() { agentmode.Enabled = prev }()
+
+	// No -o flag — should default to JSON in agent mode
+	_, output, err := execListCmd(t)
+	require.NoError(t, err)
+
+	var metrics []MetricInfo
+	require.NoError(t, json.Unmarshal([]byte(output), &metrics), "agent mode should default to JSON output")
+	assert.Len(t, metrics, 5)
 }
 
 func TestListFilterSubstring(t *testing.T) {

--- a/internal/metrics/list_cmd_test.go
+++ b/internal/metrics/list_cmd_test.go
@@ -1,0 +1,518 @@
+package metrics
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/dash0hq/dash0-cli/internal/testutil"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func labelValuesResponse(names []string) LabelValuesResponse {
+	return LabelValuesResponse{
+		Status: "success",
+		Data:   names,
+	}
+}
+
+func metadataResponse(data map[string][]MetadataEntry) MetadataResponse {
+	return MetadataResponse{
+		Status: "success",
+		Data:   data,
+	}
+}
+
+var sampleNames = []string{
+	"container_cpu_usage_seconds_total",
+	"http_server_active_requests",
+	"http_server_request_duration_seconds_bucket",
+	"http_server_request_duration_seconds_count",
+	"process_cpu_seconds_total",
+}
+
+var sampleMetadata = map[string][]MetadataEntry{
+	"container_cpu_usage_seconds_total": {{
+		Type: "counter",
+		Help: "Cumulative cpu time consumed in seconds",
+		Unit: "",
+	}},
+	"http_server_active_requests": {{
+		Type: "gauge",
+		Help: "Number of active HTTP server requests",
+		Unit: "{request}",
+	}},
+	"http_server_request_duration_seconds_bucket": {{
+		Type: "histogram",
+		Help: "Duration of HTTP server requests",
+		Unit: "s",
+	}},
+	"http_server_request_duration_seconds_count": {{
+		Type: "histogram",
+		Help: "Duration of HTTP server requests",
+		Unit: "s",
+	}},
+	"process_cpu_seconds_total": {{
+		Type: "counter",
+		Help: "Total user and system CPU time spent in seconds",
+		Unit: "s",
+	}},
+}
+
+func newTestServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "Bearer test_token", r.Header.Get("Authorization"))
+		assert.NotEmpty(t, r.Header.Get("User-Agent"))
+
+		w.Header().Set("Content-Type", "application/json")
+
+		switch {
+		case strings.Contains(r.URL.Path, "/label/__name__/values"):
+			assert.NotEmpty(t, r.URL.Query().Get("start"), "start param is required")
+			assert.NotEmpty(t, r.URL.Query().Get("end"), "end param is required")
+			json.NewEncoder(w).Encode(labelValuesResponse(sampleNames))
+
+		case strings.Contains(r.URL.Path, "/metadata"):
+			json.NewEncoder(w).Encode(metadataResponse(sampleMetadata))
+
+		default:
+			t.Errorf("unexpected request path: %s", r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+}
+
+func newErrorServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(LabelValuesResponse{
+			Status: "error",
+			Error:  "something went wrong",
+		})
+	}))
+}
+
+func setupEnv(t *testing.T, serverURL string) {
+	t.Helper()
+	t.Setenv("DASH0_API_URL", serverURL)
+	t.Setenv("DASH0_AUTH_TOKEN", "test_token")
+	t.Setenv("DASH0_CONFIG_DIR", t.TempDir())
+}
+
+func execListCmd(t *testing.T, args ...string) (*cobra.Command, string, error) {
+	t.Helper()
+
+	// Wrap in a root command with the experimental flag so RequireExperimental works
+	root := &cobra.Command{Use: "dash0"}
+	root.PersistentFlags().BoolP("experimental", "X", false, "")
+
+	metricsCmd := &cobra.Command{Use: "metrics"}
+	metricsCmd.AddCommand(newListCmd())
+	root.AddCommand(metricsCmd)
+
+	var cmdErr error
+	output := testutil.CaptureStdout(t, func() {
+		root.SetArgs(append([]string{"-X", "metrics", "list"}, args...))
+		cmdErr = root.Execute()
+	})
+	return root, output, cmdErr
+}
+
+func TestListTable(t *testing.T) {
+	server := newTestServer(t)
+	defer server.Close()
+	setupEnv(t, server.URL)
+
+	_, output, err := execListCmd(t)
+	require.NoError(t, err)
+
+	assert.Contains(t, output, "NAME")
+	assert.Contains(t, output, "http_server_active_requests")
+	assert.Contains(t, output, "container_cpu_usage_seconds_total")
+	// Table output should NOT contain type/unit metadata
+	assert.NotContains(t, output, "gauge")
+	assert.NotContains(t, output, "counter")
+}
+
+func TestListWide(t *testing.T) {
+	server := newTestServer(t)
+	defer server.Close()
+	setupEnv(t, server.URL)
+
+	_, output, err := execListCmd(t, "-o", "wide")
+	require.NoError(t, err)
+
+	assert.Contains(t, output, "NAME")
+	assert.Contains(t, output, "TYPE")
+	assert.Contains(t, output, "UNIT")
+	assert.Contains(t, output, "DESCRIPTION")
+	assert.Contains(t, output, "http_server_active_requests")
+	assert.Contains(t, output, "gauge")
+	assert.Contains(t, output, "{request}")
+	assert.Contains(t, output, "Number of active HTTP server requests")
+}
+
+func TestListJSON(t *testing.T) {
+	server := newTestServer(t)
+	defer server.Close()
+	setupEnv(t, server.URL)
+
+	_, output, err := execListCmd(t, "-o", "json")
+	require.NoError(t, err)
+
+	var metrics []MetricInfo
+	require.NoError(t, json.Unmarshal([]byte(output), &metrics))
+	assert.Len(t, metrics, 5)
+
+	// Verify sorted by name
+	assert.Equal(t, "container_cpu_usage_seconds_total", metrics[0].Name)
+	assert.Equal(t, "counter", metrics[0].Type)
+
+	assert.Equal(t, "http_server_active_requests", metrics[1].Name)
+	assert.Equal(t, "gauge", metrics[1].Type)
+	assert.Equal(t, "{request}", metrics[1].Unit)
+	assert.Equal(t, "Number of active HTTP server requests", metrics[1].Help)
+}
+
+func TestListCSV(t *testing.T) {
+	server := newTestServer(t)
+	defer server.Close()
+	setupEnv(t, server.URL)
+
+	_, output, err := execListCmd(t, "-o", "csv")
+	require.NoError(t, err)
+
+	lines := strings.Split(strings.TrimSpace(output), "\n")
+	assert.Equal(t, "name,type,unit,description", lines[0])
+	assert.GreaterOrEqual(t, len(lines), 2)
+	// Check a data row
+	assert.Contains(t, output, "http_server_active_requests,gauge,{request},Number of active HTTP server requests")
+}
+
+func TestListCSVSkipHeader(t *testing.T) {
+	server := newTestServer(t)
+	defer server.Close()
+	setupEnv(t, server.URL)
+
+	_, output, err := execListCmd(t, "-o", "csv", "--skip-header")
+	require.NoError(t, err)
+
+	assert.NotContains(t, output, "name,type,unit,description")
+	assert.Contains(t, output, "http_server_active_requests")
+}
+
+func TestListTableSkipHeader(t *testing.T) {
+	server := newTestServer(t)
+	defer server.Close()
+	setupEnv(t, server.URL)
+
+	_, output, err := execListCmd(t, "--skip-header")
+	require.NoError(t, err)
+
+	assert.NotContains(t, output, "NAME")
+	assert.Contains(t, output, "http_server_active_requests")
+}
+
+func TestListFilterSubstring(t *testing.T) {
+	server := newTestServer(t)
+	defer server.Close()
+	setupEnv(t, server.URL)
+
+	_, output, err := execListCmd(t, "--filter", "http_server")
+	require.NoError(t, err)
+
+	assert.Contains(t, output, "http_server_active_requests")
+	assert.Contains(t, output, "http_server_request_duration_seconds_bucket")
+	assert.NotContains(t, output, "container_cpu_usage_seconds_total")
+	assert.NotContains(t, output, "process_cpu_seconds_total")
+}
+
+func TestListFilterRegex(t *testing.T) {
+	server := newTestServer(t)
+	defer server.Close()
+	setupEnv(t, server.URL)
+
+	_, output, err := execListCmd(t, "--filter", "^http_server.*count$")
+	require.NoError(t, err)
+
+	assert.Contains(t, output, "http_server_request_duration_seconds_count")
+	assert.NotContains(t, output, "http_server_active_requests")
+	assert.NotContains(t, output, "http_server_request_duration_seconds_bucket")
+}
+
+func TestListLimit(t *testing.T) {
+	server := newTestServer(t)
+	defer server.Close()
+	setupEnv(t, server.URL)
+
+	_, output, err := execListCmd(t, "--limit", "2")
+	require.NoError(t, err)
+
+	lines := strings.Split(strings.TrimSpace(output), "\n")
+	// Header + 2 data rows
+	assert.Equal(t, 3, len(lines))
+}
+
+func TestListFilterAndLimit(t *testing.T) {
+	server := newTestServer(t)
+	defer server.Close()
+	setupEnv(t, server.URL)
+
+	_, output, err := execListCmd(t, "--filter", "http_server", "--limit", "1")
+	require.NoError(t, err)
+
+	lines := strings.Split(strings.TrimSpace(output), "\n")
+	// Header + 1 data row
+	assert.Equal(t, 2, len(lines))
+}
+
+func TestListEmpty(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(labelValuesResponse([]string{}))
+	}))
+	defer server.Close()
+	setupEnv(t, server.URL)
+
+	_, _, err := execListCmd(t)
+	// "No metrics found." is printed to stderr, command still succeeds
+	require.NoError(t, err)
+}
+
+func TestListFilterNoMatch(t *testing.T) {
+	server := newTestServer(t)
+	defer server.Close()
+	setupEnv(t, server.URL)
+
+	_, _, err := execListCmd(t, "--filter", "nonexistent_metric_xyz")
+	require.NoError(t, err)
+}
+
+func TestListAPIError(t *testing.T) {
+	server := newErrorServer(t)
+	defer server.Close()
+	setupEnv(t, server.URL)
+
+	_, _, err := execListCmd(t)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "something went wrong")
+}
+
+func TestListRequiresExperimental(t *testing.T) {
+	server := newTestServer(t)
+	defer server.Close()
+	setupEnv(t, server.URL)
+
+	root := &cobra.Command{Use: "dash0"}
+	root.PersistentFlags().BoolP("experimental", "X", false, "")
+
+	metricsCmd := &cobra.Command{Use: "metrics"}
+	metricsCmd.AddCommand(newListCmd())
+	root.AddCommand(metricsCmd)
+
+	root.SetArgs([]string{"metrics", "list"})
+	err := root.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "experimental")
+}
+
+func TestListTimeRangeParams(t *testing.T) {
+	var capturedStart, capturedEnd string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.URL.Path, "/label/__name__/values") {
+			capturedStart = r.URL.Query().Get("start")
+			capturedEnd = r.URL.Query().Get("end")
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(labelValuesResponse(sampleNames))
+	}))
+	defer server.Close()
+	setupEnv(t, server.URL)
+
+	_, _, err := execListCmd(t, "--from", "now-6h", "--to", "now")
+	require.NoError(t, err)
+
+	assert.NotEmpty(t, capturedStart, "start param should be set")
+	assert.NotEmpty(t, capturedEnd, "end param should be set")
+}
+
+func TestListDatasetParam(t *testing.T) {
+	var capturedDataset string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedDataset = r.URL.Query().Get("dataset")
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(labelValuesResponse(sampleNames))
+	}))
+	defer server.Close()
+
+	t.Setenv("DASH0_API_URL", server.URL)
+	t.Setenv("DASH0_AUTH_TOKEN", "test_token")
+	t.Setenv("DASH0_CONFIG_DIR", t.TempDir())
+
+	_, _, err := execListCmd(t, "--dataset", "my-dataset")
+	require.NoError(t, err)
+	assert.Equal(t, "my-dataset", capturedDataset)
+}
+
+func TestListDefaultDatasetNotSent(t *testing.T) {
+	var capturedDataset string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedDataset = r.URL.Query().Get("dataset")
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(labelValuesResponse(sampleNames))
+	}))
+	defer server.Close()
+
+	t.Setenv("DASH0_API_URL", server.URL)
+	t.Setenv("DASH0_AUTH_TOKEN", "test_token")
+	t.Setenv("DASH0_DATASET", "default")
+	t.Setenv("DASH0_CONFIG_DIR", t.TempDir())
+
+	_, _, err := execListCmd(t)
+	require.NoError(t, err)
+	assert.Empty(t, capturedDataset, "default dataset should not be sent as param")
+}
+
+func TestListInvalidFormat(t *testing.T) {
+	server := newTestServer(t)
+	defer server.Close()
+	setupEnv(t, server.URL)
+
+	_, _, err := execListCmd(t, "-o", "xml")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown output format")
+}
+
+func TestListSkipHeaderWithJSON(t *testing.T) {
+	server := newTestServer(t)
+	defer server.Close()
+	setupEnv(t, server.URL)
+
+	_, _, err := execListCmd(t, "-o", "json", "--skip-header")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--skip-header is not supported")
+}
+
+func TestListWideMetadataEndpoint(t *testing.T) {
+	var labelValuesHit, metadataHit bool
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case strings.Contains(r.URL.Path, "/label/__name__/values"):
+			labelValuesHit = true
+			json.NewEncoder(w).Encode(labelValuesResponse(sampleNames))
+		case strings.Contains(r.URL.Path, "/metadata"):
+			metadataHit = true
+			json.NewEncoder(w).Encode(metadataResponse(sampleMetadata))
+		}
+	}))
+	defer server.Close()
+	setupEnv(t, server.URL)
+
+	_, _, err := execListCmd(t, "-o", "wide")
+	require.NoError(t, err)
+	assert.False(t, labelValuesHit, "wide format should not hit label values API")
+	assert.True(t, metadataHit, "wide format should hit metadata API")
+}
+
+func TestListTableLabelValuesEndpoint(t *testing.T) {
+	var labelValuesHit, metadataHit bool
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case strings.Contains(r.URL.Path, "/label/__name__/values"):
+			labelValuesHit = true
+			json.NewEncoder(w).Encode(labelValuesResponse(sampleNames))
+		case strings.Contains(r.URL.Path, "/metadata"):
+			metadataHit = true
+			json.NewEncoder(w).Encode(metadataResponse(sampleMetadata))
+		}
+	}))
+	defer server.Close()
+	setupEnv(t, server.URL)
+
+	_, _, err := execListCmd(t)
+	require.NoError(t, err)
+	assert.True(t, labelValuesHit, "table format should hit label values API")
+	assert.False(t, metadataHit, "table format should not hit metadata API")
+}
+
+// Test that "No metrics found." is a clean exit (no error)
+func TestListEmptyFilterResult(t *testing.T) {
+	server := newTestServer(t)
+	defer server.Close()
+	setupEnv(t, server.URL)
+
+	_, stdout, err := execListCmd(t, "--filter", "zzz_nonexistent_zzz")
+	require.NoError(t, err)
+	// stdout should be empty since "No metrics found." goes to stderr
+	assert.Empty(t, strings.TrimSpace(stdout))
+}
+
+func TestListAlias(t *testing.T) {
+	server := newTestServer(t)
+	defer server.Close()
+	setupEnv(t, server.URL)
+
+	root := &cobra.Command{Use: "dash0"}
+	root.PersistentFlags().BoolP("experimental", "X", false, "")
+	metricsCmd := &cobra.Command{Use: "metrics"}
+	metricsCmd.AddCommand(newListCmd())
+	root.AddCommand(metricsCmd)
+
+	// Use "ls" alias instead of "list"
+	var cmdErr error
+	_ = testutil.CaptureStdout(t, func() {
+		root.SetArgs([]string{"-X", "metrics", "ls"})
+		cmdErr = root.Execute()
+	})
+	require.NoError(t, cmdErr)
+}
+
+func TestListAuthorizationHeader(t *testing.T) {
+	var capturedAuthHeader string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedAuthHeader = r.Header.Get("Authorization")
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(labelValuesResponse(sampleNames))
+	}))
+	defer server.Close()
+
+	t.Setenv("DASH0_API_URL", server.URL)
+	t.Setenv("DASH0_AUTH_TOKEN", "my_secret_token")
+	t.Setenv("DASH0_CONFIG_DIR", t.TempDir())
+
+	_, _, err := execListCmd(t)
+	require.NoError(t, err)
+	assert.Equal(t, "Bearer my_secret_token", capturedAuthHeader)
+}
+
+func TestListHTTPError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		w.Write([]byte("internal server error"))
+	}))
+	defer server.Close()
+	setupEnv(t, server.URL)
+
+	_, _, err := execListCmd(t)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "500")
+}
+
+func TestListMissingConfig(t *testing.T) {
+	t.Setenv("DASH0_CONFIG_DIR", t.TempDir())
+	// Don't set DASH0_API_URL or DASH0_AUTH_TOKEN
+	os.Unsetenv("DASH0_API_URL")
+	os.Unsetenv("DASH0_AUTH_TOKEN")
+
+	_, _, err := execListCmd(t)
+	require.Error(t, err)
+}

--- a/internal/metrics/list_cmd_test.go
+++ b/internal/metrics/list_cmd_test.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
-	"os"
 	"strings"
 	"testing"
 
@@ -509,9 +508,8 @@ func TestListHTTPError(t *testing.T) {
 
 func TestListMissingConfig(t *testing.T) {
 	t.Setenv("DASH0_CONFIG_DIR", t.TempDir())
-	// Don't set DASH0_API_URL or DASH0_AUTH_TOKEN
-	os.Unsetenv("DASH0_API_URL")
-	os.Unsetenv("DASH0_AUTH_TOKEN")
+	t.Setenv("DASH0_API_URL", "")
+	t.Setenv("DASH0_AUTH_TOKEN", "")
 
 	_, _, err := execListCmd(t)
 	require.Error(t, err)

--- a/internal/query/epoch.go
+++ b/internal/query/epoch.go
@@ -1,0 +1,59 @@
+package query
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// ResolveToEpochSeconds converts a time expression to a Unix epoch seconds string.
+// It handles:
+//   - "now" → current timestamp
+//   - "now-1h", "now-30m", "now-7d" → relative to now (supports d/h/m/s suffixes)
+//   - ISO 8601 absolute timestamps → parsed and converted
+func ResolveToEpochSeconds(s string) (string, error) {
+	now := time.Now()
+
+	if s == "now" {
+		return strconv.FormatInt(now.Unix(), 10), nil
+	}
+
+	if strings.HasPrefix(s, "now-") {
+		durationStr := s[4:]
+		d, err := parseRelativeDuration(durationStr)
+		if err != nil {
+			return "", fmt.Errorf("invalid relative time %q: %w", s, err)
+		}
+		return strconv.FormatInt(now.Add(-d).Unix(), 10), nil
+	}
+
+	// Try absolute timestamp formats
+	formats := []string{
+		"2006-01-02T15:04:05.000Z07:00",
+		"2006-01-02T15:04:05Z07:00",
+		"2006-01-02T15:04:05",
+		"2006-01-02",
+	}
+	for _, layout := range formats {
+		if t, err := time.Parse(layout, s); err == nil {
+			return strconv.FormatInt(t.Unix(), 10), nil
+		}
+	}
+
+	return "", fmt.Errorf("cannot parse time expression %q", s)
+}
+
+// parseRelativeDuration parses a duration string that may include "d" for days,
+// which time.ParseDuration does not support.
+func parseRelativeDuration(s string) (time.Duration, error) {
+	if strings.HasSuffix(s, "d") {
+		daysStr := strings.TrimSuffix(s, "d")
+		days, err := strconv.Atoi(daysStr)
+		if err != nil {
+			return 0, fmt.Errorf("invalid day count %q: %w", daysStr, err)
+		}
+		return time.Duration(days) * 24 * time.Hour, nil
+	}
+	return time.ParseDuration(s)
+}

--- a/internal/query/epoch_test.go
+++ b/internal/query/epoch_test.go
@@ -1,0 +1,91 @@
+package query
+
+import (
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestResolveToEpochSeconds(t *testing.T) {
+	now := time.Now().Unix()
+
+	t.Run("now", func(t *testing.T) {
+		result, err := ResolveToEpochSeconds("now")
+		require.NoError(t, err)
+		epoch, err := strconv.ParseInt(result, 10, 64)
+		require.NoError(t, err)
+		assert.InDelta(t, now, epoch, 2)
+	})
+
+	t.Run("now-1h", func(t *testing.T) {
+		result, err := ResolveToEpochSeconds("now-1h")
+		require.NoError(t, err)
+		epoch, err := strconv.ParseInt(result, 10, 64)
+		require.NoError(t, err)
+		assert.InDelta(t, now-3600, epoch, 2)
+	})
+
+	t.Run("now-30m", func(t *testing.T) {
+		result, err := ResolveToEpochSeconds("now-30m")
+		require.NoError(t, err)
+		epoch, err := strconv.ParseInt(result, 10, 64)
+		require.NoError(t, err)
+		assert.InDelta(t, now-1800, epoch, 2)
+	})
+
+	t.Run("now-7d", func(t *testing.T) {
+		result, err := ResolveToEpochSeconds("now-7d")
+		require.NoError(t, err)
+		epoch, err := strconv.ParseInt(result, 10, 64)
+		require.NoError(t, err)
+		assert.InDelta(t, now-7*86400, epoch, 2)
+	})
+
+	t.Run("absolute timestamp with timezone", func(t *testing.T) {
+		result, err := ResolveToEpochSeconds("2024-01-25T10:00:00Z")
+		require.NoError(t, err)
+		expected := time.Date(2024, 1, 25, 10, 0, 0, 0, time.UTC).Unix()
+		assert.Equal(t, strconv.FormatInt(expected, 10), result)
+	})
+
+	t.Run("absolute timestamp with millis", func(t *testing.T) {
+		result, err := ResolveToEpochSeconds("2024-01-25T10:00:00.000Z")
+		require.NoError(t, err)
+		expected := time.Date(2024, 1, 25, 10, 0, 0, 0, time.UTC).Unix()
+		assert.Equal(t, strconv.FormatInt(expected, 10), result)
+	})
+
+	t.Run("absolute date only", func(t *testing.T) {
+		result, err := ResolveToEpochSeconds("2024-01-25")
+		require.NoError(t, err)
+		expected := time.Date(2024, 1, 25, 0, 0, 0, 0, time.UTC).Unix()
+		assert.Equal(t, strconv.FormatInt(expected, 10), result)
+	})
+
+	t.Run("absolute timestamp with offset", func(t *testing.T) {
+		result, err := ResolveToEpochSeconds("2024-01-25T12:00:00+02:00")
+		require.NoError(t, err)
+		expected := time.Date(2024, 1, 25, 10, 0, 0, 0, time.UTC).Unix()
+		assert.Equal(t, strconv.FormatInt(expected, 10), result)
+	})
+
+	t.Run("invalid expression", func(t *testing.T) {
+		_, err := ResolveToEpochSeconds("garbage")
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "cannot parse time expression")
+	})
+
+	t.Run("invalid relative duration", func(t *testing.T) {
+		_, err := ResolveToEpochSeconds("now-abc")
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid relative time")
+	})
+
+	t.Run("invalid day count", func(t *testing.T) {
+		_, err := ResolveToEpochSeconds("now-abcd")
+		assert.Error(t, err)
+	})
+}


### PR DESCRIPTION
## Why

The CLI has no way to discover available metric names. Users writing PromQL queries via `dash0 metrics instant` must already know exact metric names. The only discovery path today is the Dash0 UI Metric Explorer.

## What

Adds `dash0 -X metrics list` for metric name discovery, backed by the Prometheus-compatible label values and metadata APIs.

- **`-o table`** (default): Single NAME column via label values API (~850ms, ~348KB)
- **`-o wide`**: NAME + TYPE + UNIT + DESCRIPTION via metadata API (~2s, ~1.1MB)
- **`-o json`**: Array of objects with full metadata
- **`-o csv`**: Same columns as wide
- `--filter` for substring/regex matching on metric names (client-side)
- `--from`/`--to` time range (default: last 1 hour)
- `--limit`, `--skip-header`, `--dataset` flags
- New shared `ResolveToEpochSeconds()` utility for Prometheus API time params

Linear: ENG-7969

🤖 Generated with [Claude Code](https://claude.com/claude-code)