### PR TITLE
feat: add --profile flag and DASH0_PROFILE env var

### DIFF
--- a/.chloggen/add-profile-parameter.yaml
+++ b/.chloggen/add-profile-parameter.yaml
@@ -1,0 +1,17 @@
+change_type: enhancement
+
+component: config
+
+note: Add `--profile` global flag and `DASH0_PROFILE` environment variable to select a profile per invocation.
+
+issues: [127]
+
+subtext: |
+  The selector overrides the active profile on disk for the current invocation
+  without modifying `~/.dash0/`. Precedence is `--profile` flag → `DASH0_PROFILE`
+  → the active profile. A non-existent profile fails before any API call with a
+  message listing the available profiles. Passing an empty value falls through
+  to the next step. `config show` annotates the `Profile:` line with the source
+  when a selector is in effect.
+
+change_logs: []

--- a/README.md
+++ b/README.md
@@ -396,6 +396,7 @@ dash0 -X api /api/organization/settings --dataset ""
 | `--color` | | `DASH0_COLOR` | Color mode for output: `semantic` (default) or `none`. Ignored when piping output. |
 | `--dataset` | | `DASH0_DATASET` | Override dataset from profile. Use the `identifier`, not `Name`. |
 | `--experimental` | `-X` | | Enable experimental features (required for commands marked `[experimental]`) |
+| `--profile` | | `DASH0_PROFILE` | Use a named profile for this invocation without changing the active profile. |
 | `--file` | `-f` | | Input file path (use `-` for stdin) |
 | `--output` | `-o` | | Output format: `table`, `wide`, `json`, `yaml`, `csv` |
 | | | `DASH0_CONFIG_DIR` | Override the configuration directory (default: `~/.dash0`) |

--- a/cmd/dash0/main.go
+++ b/cmd/dash0/main.go
@@ -83,6 +83,7 @@ func init() {
 	rootCmd.PersistentFlags().BoolP("experimental", "X", false, "Enable experimental features")
 	rootCmd.PersistentFlags().String("color", "", `Color mode for output: "semantic" or "none" (env: DASH0_COLOR)`)
 	rootCmd.PersistentFlags().Bool("agent-mode", false, "Enable agent mode for AI coding agents (env: DASH0_AGENT_MODE)")
+	rootCmd.PersistentFlags().String("profile", "", "Profile to use for this invocation; overrides the active profile on disk (env: DASH0_PROFILE)")
 }
 
 // newVersionCmd creates a new version command
@@ -147,6 +148,30 @@ func loadConfig() *profiles.Configuration {
 	return cfg
 }
 
+// flagValue returns the value of the named long-form flag in args, or empty
+// string if it is not present. It supports both `--name value` and
+// `--name=value` forms. It stops scanning after "--" (end of flags).
+// This is used before cobra has parsed flags, so we scan manually.
+func flagValue(args []string, name string) string {
+	prefix := "--" + name
+	for i := 0; i < len(args); i++ {
+		arg := args[i]
+		if arg == "--" {
+			return ""
+		}
+		if arg == prefix {
+			if i+1 < len(args) {
+				return args[i+1]
+			}
+			return ""
+		}
+		if strings.HasPrefix(arg, prefix+"=") {
+			return strings.TrimPrefix(arg, prefix+"=")
+		}
+	}
+	return ""
+}
+
 func resolveColorMode() (colorMode, error) {
 	flagVal, _ := rootCmd.PersistentFlags().GetString("color")
 	raw := flagVal
@@ -197,12 +222,25 @@ func main() {
 		dashcolor.NoColor = true
 	}
 
-	// Always attempt to load configuration. Commands that don't need it
-	// (help, version, config) simply ignore it. Commands that do need it
-	// will fail with a clear error if the required values are missing.
-	if cfg := loadConfig(); cfg != nil {
+	// Resolve the per-invocation profile selector (--profile flag or
+	// DASH0_PROFILE env var) before loading config so the selection flows
+	// into both the loaded configuration and the context consumed by
+	// `config show`.
+	selector := config.ResolveProfileSelector(flagValue(os.Args[1:], "profile"))
+	if selector.IsSet() {
+		cfg, err := config.ResolveConfigurationForProfile(selector.Name)
+		if err != nil {
+			printError(err)
+			os.Exit(1)
+		}
+		ctx = profiles.WithConfiguration(ctx, cfg)
+	} else if cfg := loadConfig(); cfg != nil {
+		// Always attempt to load configuration. Commands that don't need it
+		// (help, version, config) simply ignore it. Commands that do need it
+		// will fail with a clear error if the required values are missing.
 		ctx = profiles.WithConfiguration(ctx, cfg)
 	}
+	ctx = config.WithProfileSelector(ctx, selector)
 
 	if err := rootCmd.ExecuteContext(ctx); err != nil {
 		printError(err)

--- a/cmd/dash0/main_test.go
+++ b/cmd/dash0/main_test.go
@@ -38,3 +38,30 @@ func TestRootCommandExecution(t *testing.T) {
 		t.Errorf("Help output did not contain expected content")
 	}
 }
+
+// TestFlagValue covers the manual flag scanning used before cobra parses flags.
+func TestFlagValue(t *testing.T) {
+	cases := []struct {
+		name string
+		args []string
+		flag string
+		want string
+	}{
+		{"not present", []string{"foo", "bar"}, "profile", ""},
+		{"space-separated", []string{"--profile", "prod", "cmd"}, "profile", "prod"},
+		{"equals form", []string{"--profile=prod", "cmd"}, "profile", "prod"},
+		{"value missing at end", []string{"--profile"}, "profile", ""},
+		{"empty equals value", []string{"--profile=", "cmd"}, "profile", ""},
+		{"stops at --", []string{"--", "--profile", "prod"}, "profile", ""},
+		{"does not match prefix only", []string{"--profiled", "prod"}, "profile", ""},
+		{"first match wins", []string{"--profile", "first", "--profile", "second"}, "profile", "first"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := flagValue(tc.args, tc.flag)
+			if got != tc.want {
+				t.Errorf("flagValue(%v, %q) = %q, want %q", tc.args, tc.flag, got, tc.want)
+			}
+		})
+	}
+}

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -40,11 +40,21 @@ It is experimental.
 ## Prerequisites
 
 Every command that talks to the Dash0 API or OTLP endpoint needs credentials.
-The CLI resolves configuration in this order (first match wins):
+The CLI resolves each individual setting (`api-url`, `otlp-url`, `auth-token`, `dataset`) in this order (first match wins):
 
 1. Environment variables (`DASH0_API_URL`, `DASH0_OTLP_URL`, `DASH0_AUTH_TOKEN`, `DASH0_DATASET`)
 2. CLI flags (`--api-url`, `--otlp-url`, `--auth-token`, `--dataset`)
-3. The active profile (stored in `~/.dash0/`)
+3. The selected profile (see below)
+
+The profile itself is selected in this order (first match wins):
+
+1. `--profile <name>` flag
+2. `DASH0_PROFILE` environment variable
+3. The active profile recorded on disk (set via `config profiles select`, stored in `~/.dash0/`)
+
+Using `--profile` or `DASH0_PROFILE` does not modify the active profile on disk — it only changes which profile is read for the current invocation.
+Passing `--profile ""` or `DASH0_PROFILE=""` is treated as "not set" and falls through to the next step.
+If the selected profile does not exist, the command fails before making any API call with a message listing the available profile names.
 
 Commands that read from the API (asset CRUD, `logs query`, `spans query`, `traces get`, `metrics instant`) require `api-url` and `auth-token`.
 Commands that write via OTLP (`logs send`, `spans send`) require `otlp-url` and `auth-token`.
@@ -59,6 +69,7 @@ These flags are available on every command:
 | `--otlp-url` | | `DASH0_OTLP_URL` | OTLP HTTP endpoint URL |
 | `--auth-token` | | `DASH0_AUTH_TOKEN` | Authentication token |
 | `--dataset` | | `DASH0_DATASET` | Dataset identifier (not display name) |
+| `--profile` | | `DASH0_PROFILE` | Profile to use for this invocation; overrides the active profile on disk |
 | `--agent-mode` | | `DASH0_AGENT_MODE` | Enable agent mode for AI coding agents (see below) |
 | `--color` | | `DASH0_COLOR` | `semantic` (default) or `none` |
 | `--experimental` | `-X` | | Enable experimental commands |
@@ -196,7 +207,7 @@ Aliases: `remove`
 
 ### `config show`
 
-Display the resolved configuration (active profile + environment variable overrides).
+Display the resolved configuration (selected profile + environment variable overrides).
 
 ```bash
 dash0 config show
@@ -221,6 +232,18 @@ API URL:    http://test    (from DASH0_API_URL environment variable)
 OTLP URL:   https://ingress.us-west-2.aws.dash0.com
 Dataset:    default
 Auth Token: ...ULSzVkM
+```
+
+When a profile is selected via `--profile` or `DASH0_PROFILE`, the `Profile:` line is annotated with the source:
+
+```bash
+$ dash0 --profile prod config show
+Profile:    prod    (from --profile flag)
+...
+
+$ DASH0_PROFILE=prod dash0 config show
+Profile:    prod    (from DASH0_PROFILE environment variable)
+...
 ```
 
 ## Asset CRUD commands

--- a/docs/origin-and-immutability-analysis.md
+++ b/docs/origin-and-immutability-analysis.md
@@ -1,0 +1,343 @@
+# Origin, source, and immutability: cross-asset analysis
+
+This document analyzes how the `origin` field, the `source` annotation, and the `createAsUiAsset` query parameter interact to control asset mutability across all asset types in the Dash0 backend.
+The goal is to identify inconsistencies that should be standardized.
+
+## Concepts
+
+Three related but distinct mechanisms control whether an asset is editable in the UI:
+
+| Concept | What it is | Where it lives | What it controls |
+|---------|-----------|----------------|-----------------|
+| **Origin** | A string identifier stored in the database when an asset is created programmatically | DB column (`origin`) or label (`dash0.com/origin`) | Whether `permittedActions` includes `write` for admins |
+| **Source** | A derived annotation computed from origin at read time | Annotation (`dash0.com/source`) on dashboards; label (`dash0.com/source`) on views | Additional UI restrictions beyond permissions (e.g., folder moves for dashboards) |
+| **`createAsUiAsset`** | A query parameter on POST endpoints that controls whether the asset is treated as UI-created; available on all four asset types (dashboards, views, check rules, synthetic checks) but not on notification channels; only on POST, not PUT or DELETE | Request parameter, not persisted | Whether origin gets an `"api-"` prefix; whether admin write permission is granted at creation |
+
+### How origin controls immutability
+
+All asset types determine `permittedActions` based on origin:
+- **Origin is empty/nil** → admin gets `read + write + delete` → **editable** in UI.
+- **Origin is non-empty** → admin gets `read + delete` (no `write`) → **immutable** in UI.
+
+### How origin is stored (the UUID gate)
+
+All asset types share the same database-layer pattern when creating a new asset:
+
+```go
+id, err := uuid.Parse(originOrId)
+isUuid := err == nil
+if !isUuid {
+    origin = &originOrId   // stored → immutable
+}
+// if isUuid → origin stays nil → editable
+```
+
+This means the **format** of the `originOrId` value silently determines mutability:
+- Valid UUID → origin not stored → editable.
+- Anything else (including `"api-<uuid>"`) → origin stored → immutable.
+
+## Per-asset analysis
+
+### Dashboards
+
+#### Origin generation
+
+| Code path | `originOrId` value | Origin stored? |
+|-----------|-------------------|----------------|
+| POST without `createAsUiAsset` | `"api-<uuid>"` via `generateAPIDashboardOriginOrId()` | Yes |
+| POST with `createAsUiAsset=true` | bare UUID | No |
+| POST without `createAsUiAsset`, YAML has `Dash0Extensions.Id` | value of `Dash0Extensions.Id` (overrides `"api-"` prefix) | Depends on format |
+| PUT (any) | URL path parameter as-is | Depends on format |
+
+#### Permission logic
+
+Set at the **route layer** (`dashboards.go:390–396`) based on `createAsUiAsset`:
+
+```go
+adminActions := []DashboardAction{DashboardsRead, DashboardsDelete}
+if createAsUiAsset {
+    adminActions = append(adminActions, DashboardsWrite)
+}
+```
+
+Members always get `DashboardsRead` only.
+
+For PUT (both machine tokens and user tokens), `createAsUiAsset` is hardcoded to `false` (`dashboards_api.go:353`, `dashboards.go:695`).
+This means updating an existing dashboard via PUT always sets admin permissions to read + delete only, even if the original dashboard was UI-created.
+**This is a bug: PUT overwrites existing permissions with restricted defaults.**
+
+#### Source annotation
+
+Dashboards have a **derived** `dash0.com/source` annotation, computed from origin at read time by `getDashboardSource()` (`dashboard.go:2220–2233`):
+
+| Origin value | Source | UI effect |
+|-------------|--------|-----------|
+| nil / empty | `"ui"` | Fully editable, can move to folders |
+| Starts with `"tf_"` | `"terraform"` | Cannot move to folders |
+| Starts with `"dash0-operator_"` | `"operator"` | Cannot move to folders |
+| Anything else | `"api"` | Cannot move to folders |
+
+The source annotation controls **folder operations** in the frontend (`dashboard-list/utils.ts:99–121`), which is separate from the `permittedActions` check that controls **editing** (`use-can-edit-dashboard.ts:42`).
+
+Both checks must pass for full editability: the dashboard needs `dashboards:write` in `permittedActions` AND source must not be `"api"`, `"terraform"`, or `"operator"` for folder operations.
+
+#### Files
+
+- Route layer: `control-plane-api/internal/routes/dashboards.go` (lines 279–438), `dashboards_api.go` (lines 180–365)
+- DB layer: `control-plane-api/internal/database/dashboard.go` (lines 1359–1456, 2078–2233)
+- Frontend: `ui/src/dashboarding/pages/dashboard-viewer/use-can-edit-dashboard.ts`, `ui/src/dashboarding/pages/dashboard-list/utils.ts`
+
+---
+
+### Check rules
+
+#### Origin generation
+
+| Code path | `originOrId` value | Origin stored? |
+|-----------|-------------------|----------------|
+| POST (machine token), no ID in body | `"api-<uuid>"` | Yes |
+| POST (machine token), ID in body | `"api-<id>"` | Yes (unless ID is a UUID, then `"api-<uuid>"` fails UUID parse regardless) |
+| POST (user token), no ID in body | `"api-<uuid>"` but `createAsUiAsset` auto-set to `true` locally (see note) | Yes |
+| POST with `createAsUiAsset=true` | bare UUID | No |
+| PUT (any) | URL path parameter as-is | Depends on format |
+
+**Note on auto-set `createAsUiAsset`**: In the public API user-token path (`checkrules_api.go:172–174`), when no ID is provided, the local variable `createAsUiAsset` is set to `true`.
+However, the `if` condition on line 176 checks `request.Params.CreateAsUiAsset` (the request parameter), not the local variable.
+Since the request parameter is nil, the `"api-"` prefix is **still applied**.
+The local `createAsUiAsset=true` is then passed to `putOrganizationCheckRuleInternal` as the `isUpdate` parameter, where it is used only for validation logic—not for permission or origin decisions.
+This means the auto-set has **no effect on origin or permissions** for user tokens.
+
+#### Permission logic
+
+Set at the **database layer** (`checkrule.go:2480–2512`) based on `origin != nil`:
+
+```go
+checkRuleCreatedViaAPI := origin != nil && *origin != ""
+if auth.ClerkOrganizationRole == AdminRole {
+    if !checkRuleCreatedViaAPI {
+        permittedActions[CheckRuleWrite] = true
+    }
+    permittedActions[CheckRuleDelete] = true
+}
+```
+
+**Architectural difference from dashboards/views**: permissions are not set at the route layer via `createAsUiAsset`; they are computed at read time from the stored origin.
+This means check rules cannot have their permissions incorrectly overwritten by PUT (unlike dashboards/views), but it also means the only way to make a check rule editable is to ensure origin is nil.
+
+#### Source annotation
+
+Check rules do **not** have a `dash0.com/source` annotation.
+Immutability is determined solely by `permittedActions` in the UI (`use-can-edit-check-rule.tsx`).
+The frontend uses `isCreatedByAPI(checkRule)` which checks `checkRule.origin != null`.
+
+#### Files
+
+- Route layer: `control-plane-api/internal/routes/checkrules.go` (lines 707–918), `checkrules_api.go` (lines 103–330)
+- DB layer: `control-plane-api/internal/database/checkrule.go` (lines 1554–1614, 2480–2530)
+- Frontend: `ui/src/alerting/utils/use-can-edit-check-rule.tsx`, `ui/src/alerting/pages/check-rule-list-page/components/check-rule-title.tsx`
+
+---
+
+### Views
+
+#### Origin generation
+
+| Code path | `originOrId` value | Origin stored? |
+|-----------|-------------------|----------------|
+| POST without `createAsUiAsset` | `"api-<uuid>"` (or override from `Dash0Comorigin` label) | Yes |
+| POST with `createAsUiAsset=true` | bare UUID | No |
+| PUT (any) | URL path parameter as-is | Depends on format |
+
+#### Permission logic
+
+Set at the **route layer** (`views.go:590–621`) based on `createAsUiAsset`, **identical pattern to dashboards**:
+
+```go
+adminActions := []ViewAction{ViewsRead, ViewsDelete}
+if createAsUiAsset {
+    adminActions = append(adminActions, ViewsWrite)
+}
+```
+
+For PUT, `createAsUiAsset` is hardcoded to `false` (`views_api.go:357`, `views.go:458`).
+**Same bug as dashboards: PUT overwrites permissions with restricted defaults.**
+
+#### Source annotation
+
+Views have a `dash0.com/source` **label** (not annotation) with three values:
+
+| Value | Meaning |
+|-------|---------|
+| `"builtin"` | System-provided default views |
+| `"external"` | Created via API with non-UUID origin |
+| `"userdefined"` | Created by users in UI |
+
+The source label is set:
+- To `"external"` by the database layer on update when `originOrId` is not a UUID (`view.go:1532–1533`).
+- By the request body when the caller provides it (validated to be `"userdefined"` or `"external"` only; `views.go:485`).
+
+#### Files
+
+- Route layer: `control-plane-api/internal/routes/views.go` (lines 470–641), `views_api.go` (lines 181–369)
+- DB layer: `control-plane-api/internal/database/view.go` (lines 1455–1534)
+- Utility: `control-plane-api/internal/utils/view.go` (lines 64–75)
+
+---
+
+### Synthetic checks
+
+#### Origin generation
+
+| Code path | `originOrId` value | Origin stored? |
+|-----------|-------------------|----------------|
+| POST without `createAsUiAsset` | `"api-<uuid>"` (or override from `Dash0Comorigin` label) | Yes |
+| POST with `createAsUiAsset=true` | bare UUID | No |
+| PUT (any) | URL path parameter as-is | Depends on format |
+
+#### Permission logic
+
+Set at the **database layer** (`synthetic_check.go:2264–2296`) based on `origin != nil`, **identical pattern to check rules**:
+
+```go
+syntheticCheckCreatedViaAPI := labels.Dash0Comorigin != nil && *labels.Dash0Comorigin != ""
+if auth.ClerkOrganizationRole == AdminRole {
+    if !syntheticCheckCreatedViaAPI {
+        permittedActions[SyntheticCheckWrite] = true
+    }
+    permittedActions[SyntheticCheckDelete] = true
+}
+```
+
+**Architectural difference from dashboards/views**: same as check rules — permissions computed at read time from origin, not set at creation time via `createAsUiAsset`.
+
+#### Source annotation
+
+Synthetic checks do **not** have a `dash0.com/source` annotation.
+Immutability is determined solely by `permittedActions` and `isCreatedByAPI()` in the frontend (`synthetics/pages/synthetics-detail-page/utils/is-created-by-api.ts`).
+
+#### Files
+
+- Route layer: `control-plane-api/internal/routes/synthetic_checks.go` (lines 690–964), `synthetic_checks_api.go` (lines 104–337)
+- DB layer: `control-plane-api/internal/database/synthetic_check.go` (lines 1295–1461, 2264–2321)
+- Frontend: `ui/src/synthetics/pages/synthetics-detail-page/utils/is-created-by-api.ts`
+
+---
+
+### Notification channels
+
+Notification channels do **not** participate in the origin/immutability system.
+They are the only asset type managed by the CLI where origin has no effect on editability.
+
+#### Origin handling
+
+- Origin is stored directly from the request body (`dash0.com/origin` label), not auto-generated by the backend.
+- There is no `createAsUiAsset` parameter (not in the OpenAPI spec, not in the route handlers).
+- There is no `"api-"` prefix logic.
+- UUID collision validation exists (`validateNotificationChannelOrigin`) but no `uuid.Parse` gate for deciding whether to store origin.
+
+#### Permission logic
+
+Simple admin-role check: only admins can create, update, or delete notification channels (`requireAdminRole()` in the public API, `CheckUserAuthAndExpectAdminRoleInOrganization()` in the internal API).
+There are no fine-grained `permittedActions`, no `isActionable` checks, and no origin-based write guards — in the backend, the database layer, or the frontend.
+Any admin can edit or delete any notification channel regardless of whether it has an origin.
+
+#### Cannot be made read-only
+
+Unlike the other four asset types, notification channels **cannot** be made immutable.
+There is no mechanism — origin-based, permission-based, or otherwise — to prevent an admin from modifying a notification channel.
+The frontend does not render `ReadOnlyTag` or disable edit/delete buttons based on origin.
+
+#### Source annotation
+
+No `dash0.com/source` annotation.
+
+#### Files
+
+- Route layer: `control-plane-api/internal/routes/notificationchannels.go`, `notificationchannels_api.go`
+- DB layer: `control-plane-api/internal/database/notificationchannel.go`
+- Service layer: `control-plane-api/internal/service/notification_channel_service/`
+
+---
+
+## Summary of inconsistencies
+
+### 1. Permission logic lives in two different places
+
+| Asset type | Where admin write permission is determined |
+|-----------|-------------------------------------------|
+| **Dashboards** | Route layer, at creation/update time, based on `createAsUiAsset` |
+| **Views** | Route layer, at creation/update time, based on `createAsUiAsset` |
+| **Check rules** | Database layer, at read time, based on `origin != nil` |
+| **Synthetic checks** | Database layer, at read time, based on `origin != nil` |
+
+**Impact**: For dashboards and views, PUT always sets `createAsUiAsset=false`, which overwrites permissions to read+delete even on existing editable assets.
+For check rules and synthetic checks, permissions are always computed from the current origin value, so they cannot be accidentally overwritten.
+
+### 2. The `source` annotation is not standardized
+
+| Asset type | Has source annotation? | Values | Derived from origin? |
+|-----------|----------------------|--------|---------------------|
+| **Dashboards** | Yes (`dash0.com/source` annotation) | `ui`, `api`, `terraform`, `operator` | Yes, at read time via `getDashboardSource()` |
+| **Views** | Yes (`dash0.com/source` label) | `builtin`, `external`, `userdefined` | Partially (set to `"external"` on update when origin is non-UUID) |
+| **Check rules** | No | — | — |
+| **Synthetic checks** | No | — | — |
+
+The enum values are completely different between dashboards and views, and two asset types lack the annotation entirely.
+
+### 3. The `uuid.Parse` gate creates format-dependent behavior
+
+All four asset types use the same `uuid.Parse(originOrId)` check in the database layer to decide whether to store origin.
+This means the **format** of a user-provided ID silently determines mutability:
+
+| ID format | Origin stored? | Asset editable in UI? |
+|-----------|---------------|----------------------|
+| `"a1b2c3d4-5678-90ab-cdef-1234567890ab"` (UUID) | No | Yes |
+| `"prod-overview"` (slug) | Yes | No |
+| `"api-a1b2c3d4-..."` (auto-generated by POST) | Yes | No |
+
+There is no documentation or user-facing signal that explains this behavior.
+
+### 4. The CLI never passes `createAsUiAsset`
+
+The Go API client (`dash0-api-client-go`) does not expose the `createAsUiAsset` query parameter on any endpoint.
+As a result:
+- All CLI-created assets via POST get an `"api-"` prefixed origin → always immutable.
+- CLI-created assets via PUT with a UUID ID → origin not stored → editable.
+- CLI-created assets via PUT with a slug ID → origin stored → immutable.
+
+### 5. PUT hardcodes `createAsUiAsset=false` for dashboards and views
+
+Both the public API PUT and the internal PUT handlers pass `createAsUiAsset=false`:
+- `dashboards_api.go:353`, `dashboards.go:695`
+- `views_api.go:357`, `views.go:458`
+
+This means every PUT (update) operation on dashboards and views resets admin permissions to read+delete only.
+If a dashboard was originally created with `createAsUiAsset=true` (editable), updating it via PUT makes it immutable.
+
+### 6. Check rules auto-set `createAsUiAsset` in user-token path (but it has no effect)
+
+In the public API user-token path for check rules (`checkrules_api.go:172–174`), the local variable `createAsUiAsset` is set to `true` when no ID is provided.
+But the `"api-"` prefix is still applied because the condition checks `request.Params.CreateAsUiAsset` (nil), not the local variable.
+The local variable is then passed as `isUpdate` to the internal handler, where it is only used for validation — not for permission decisions.
+This is confusing code that has no practical effect.
+
+### 7. Notification channels have no immutability mechanism
+
+The other four asset types all support making assets immutable via origin.
+Notification channels do not — origin is just an external identifier for upsert semantics.
+Any admin can edit or delete any notification channel, regardless of who or what created it.
+If notification channels should be manageable as code (like the other asset types), they need the same immutability guarantees to prevent UI users from accidentally overwriting programmatically-managed configurations.
+
+## Recommendations
+
+1. **Standardize where permission logic lives**: either always at the route layer (like dashboards/views) or always at the database layer (like check rules/synthetic checks), not a mix.
+
+2. **Standardize the `source` annotation**: either all asset types have it with a common enum, or none do. The current state (dashboards and views with different enums, check rules and synthetic checks without) is confusing.
+
+3. **Decouple mutability from ID format**: the `uuid.Parse` gate should not be the mechanism that determines whether an asset is externally managed. Use an explicit signal (e.g., a `managed-by` annotation or the `createAsUiAsset` parameter).
+
+4. **Fix the PUT permission overwrite bug**: PUT should not reset admin permissions when updating an existing asset. Either preserve existing permissions or compute them from the current origin (like check rules and synthetic checks do).
+
+5. **Expose `createAsUiAsset` in the API client**: the CLI should be able to create assets that are editable in the UI, just like the Dash0 UI itself does.
+
+6. **Clean up the dead auto-set in check rules**: the `createAsUiAsset = true` assignment in `checkrules_api.go:174` has no practical effect and should be removed or fixed to actually work.

--- a/internal/config/config_cmd.go
+++ b/internal/config/config_cmd.go
@@ -29,11 +29,11 @@ func NewConfigCmd() *cobra.Command {
 
 // configShowJSON is the JSON-serializable representation of config show output.
 type configShowJSON struct {
-	Profile   string              `json:"profile"`
-	ApiUrl    *configShowField    `json:"apiUrl"`
-	OtlpUrl   *configShowField    `json:"otlpUrl"`
-	Dataset   *configShowField    `json:"dataset"`
-	AuthToken *configShowField    `json:"authToken"`
+	Profile   *configShowField `json:"profile"`
+	ApiUrl    *configShowField `json:"apiUrl"`
+	OtlpUrl   *configShowField `json:"otlpUrl"`
+	Dataset   *configShowField `json:"dataset"`
+	AuthToken *configShowField `json:"authToken"`
 }
 
 type configShowField struct {
@@ -68,10 +68,7 @@ The DASH0_CONFIG_DIR environment variable changes the configuration directory (d
   # Use a different configuration directory
   DASH0_CONFIG_DIR=/tmp/dash0-test dash0 config show`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			store, err := profiles.NewStore()
-			if err != nil {
-				return err
-			}
+			profileSelector := ProfileSelectorFromContext(cmd.Context())
 
 			// Check if environment variables are being used
 			envApiUrl := os.Getenv(profiles.EnvApiUrl)
@@ -80,12 +77,26 @@ The DASH0_CONFIG_DIR environment variable changes the configuration directory (d
 			envDataset := os.Getenv(profiles.EnvDataset)
 
 			profileName := ""
-			activeProfile, err := store.GetActiveProfile()
-			if err == nil && activeProfile != nil {
-				profileName = activeProfile.Name
-			}
+			var config *profiles.Configuration
 
-			config, _ := store.GetActiveConfiguration()
+			if profileSelector.IsSet() {
+				profileName = profileSelector.Name
+				resolved, err := ResolveConfigurationForProfile(profileSelector.Name)
+				if err != nil {
+					return err
+				}
+				config = resolved
+			} else {
+				store, err := profiles.NewStore()
+				if err != nil {
+					return err
+				}
+				activeProfile, err := store.GetActiveProfile()
+				if err == nil && activeProfile != nil {
+					profileName = activeProfile.Name
+				}
+				config, _ = store.GetActiveConfiguration()
+			}
 
 			apiUrl := ""
 			authToken := ""
@@ -108,7 +119,7 @@ The DASH0_CONFIG_DIR environment variable changes the configuration directory (d
 
 			if useJSON {
 				result := configShowJSON{
-					Profile:   profileName,
+					Profile:   profileField(profileName, profileSelector),
 					ApiUrl:    showField(apiUrl, envApiUrl, profiles.EnvApiUrl),
 					OtlpUrl:   showField(otlpUrl, envOtlpUrl, profiles.EnvOtlpUrl),
 					Dataset:   showField(datasetDisplay, envDataset, profiles.EnvDataset),
@@ -121,10 +132,14 @@ The DASH0_CONFIG_DIR environment variable changes the configuration directory (d
 
 			fmt.Printf("Profile:    ")
 			if profileName == "" {
-				fmt.Printf("(none)\n")
+				fmt.Printf("(none)")
 			} else {
-				fmt.Printf("%s\n", profileName)
+				fmt.Printf("%s", profileName)
 			}
+			if desc := profileSelector.Source.Description(); desc != "" {
+				fmt.Printf("    (%s)", desc)
+			}
+			fmt.Println()
 
 			if apiUrl != "" {
 				fmt.Printf("API URL:    %s", apiUrl)
@@ -175,6 +190,17 @@ func showField(value, envVar, envName string) *configShowField {
 	f := &configShowField{Value: value}
 	if envVar != "" {
 		f.Source = envName
+	}
+	return f
+}
+
+func profileField(name string, selector ProfileSelector) *configShowField {
+	f := &configShowField{Value: name}
+	switch selector.Source {
+	case ProfileSourceFlag:
+		f.Source = "flag:--profile"
+	case ProfileSourceEnv:
+		f.Source = EnvProfile
 	}
 	return f
 }

--- a/internal/config/config_cmd_test.go
+++ b/internal/config/config_cmd_test.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"io"
 	"os"
@@ -846,5 +847,230 @@ func TestActivateProfileAlias(t *testing.T) {
 
 	if activeProfile.Name != "test2" {
 		t.Errorf("Expected active profile name test2, got %s", activeProfile.Name)
+	}
+}
+
+// executeCommandWithContext is like executeCommand but runs the command with
+// a caller-supplied context. It is used by tests that need to seed the
+// profile selector into the context.
+func executeCommandWithContext(ctx context.Context, root *cobra.Command, args ...string) (string, error) {
+	stdout := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	root.SetArgs(args)
+	execErr := root.ExecuteContext(ctx)
+
+	w.Close()
+	os.Stdout = stdout
+
+	var buf bytes.Buffer
+	_, _ = io.Copy(&buf, r)
+
+	return buf.String(), execErr
+}
+
+// TestShowCmdProfileSelectorFlag verifies that config show uses the profile
+// selected via the --profile flag (seeded into the context) and annotates
+// the source on the Profile: line.
+func TestShowCmdProfileSelectorFlag(t *testing.T) {
+	configDir := setupTestConfigDir(t)
+
+	testProfiles := []profiles.Profile{
+		{
+			Name: "dev",
+			Configuration: profiles.Configuration{
+				ApiUrl:    "https://api-dev.example.com",
+				AuthToken: "dev_token",
+			},
+		},
+		{
+			Name: "prod",
+			Configuration: profiles.Configuration{
+				ApiUrl:    "https://api-prod.example.com",
+				AuthToken: "prod_token",
+			},
+		},
+	}
+	createTestProfilesFile(t, configDir, testProfiles)
+	setActiveProfile(t, configDir, "dev")
+
+	ctx := WithProfileSelector(context.Background(), ProfileSelector{
+		Name:   "prod",
+		Source: ProfileSourceFlag,
+	})
+
+	rootCmd := &cobra.Command{Use: "dash0"}
+	rootCmd.AddCommand(NewConfigCmd())
+
+	output, err := executeCommandWithContext(ctx, rootCmd, "config", "show")
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	if !bytes.Contains([]byte(output), []byte("Profile:    prod    (from --profile flag)")) {
+		t.Errorf("Expected 'Profile:    prod    (from --profile flag)', got:\n%s", output)
+	}
+	if !bytes.Contains([]byte(output), []byte("https://api-prod.example.com")) {
+		t.Errorf("Expected prod api url in output, got:\n%s", output)
+	}
+}
+
+// TestShowCmdProfileSelectorEnv verifies that config show annotates the
+// source with the environment variable name when selected via DASH0_PROFILE.
+func TestShowCmdProfileSelectorEnv(t *testing.T) {
+	configDir := setupTestConfigDir(t)
+
+	testProfiles := []profiles.Profile{
+		{
+			Name: "dev",
+			Configuration: profiles.Configuration{
+				ApiUrl:    "https://api-dev.example.com",
+				AuthToken: "dev_token",
+			},
+		},
+		{
+			Name: "prod",
+			Configuration: profiles.Configuration{
+				ApiUrl:    "https://api-prod.example.com",
+				AuthToken: "prod_token",
+			},
+		},
+	}
+	createTestProfilesFile(t, configDir, testProfiles)
+	setActiveProfile(t, configDir, "dev")
+
+	ctx := WithProfileSelector(context.Background(), ProfileSelector{
+		Name:   "prod",
+		Source: ProfileSourceEnv,
+	})
+
+	rootCmd := &cobra.Command{Use: "dash0"}
+	rootCmd.AddCommand(NewConfigCmd())
+
+	output, err := executeCommandWithContext(ctx, rootCmd, "config", "show")
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	if !bytes.Contains([]byte(output), []byte("Profile:    prod    (from DASH0_PROFILE environment variable)")) {
+		t.Errorf("Expected env annotation, got:\n%s", output)
+	}
+}
+
+// TestShowCmdProfileSelectorUnknown verifies that config show returns the
+// profile-not-found error when the selector points at a missing profile.
+func TestShowCmdProfileSelectorUnknown(t *testing.T) {
+	configDir := setupTestConfigDir(t)
+
+	testProfiles := []profiles.Profile{
+		{
+			Name: "dev",
+			Configuration: profiles.Configuration{
+				ApiUrl:    "https://api-dev.example.com",
+				AuthToken: "dev_token",
+			},
+		},
+	}
+	createTestProfilesFile(t, configDir, testProfiles)
+	setActiveProfile(t, configDir, "dev")
+
+	ctx := WithProfileSelector(context.Background(), ProfileSelector{
+		Name:   "typo",
+		Source: ProfileSourceFlag,
+	})
+
+	rootCmd := &cobra.Command{Use: "dash0"}
+	rootCmd.AddCommand(NewConfigCmd())
+
+	_, err := executeCommandWithContext(ctx, rootCmd, "config", "show")
+	if err == nil {
+		t.Fatal("Expected error for unknown profile selector, got nil")
+	}
+	if !bytes.Contains([]byte(err.Error()), []byte(`profile "typo" does not exist`)) {
+		t.Errorf("Expected profile-not-exist error, got: %v", err)
+	}
+	if !bytes.Contains([]byte(err.Error()), []byte("dev")) {
+		t.Errorf("Expected available profiles list, got: %v", err)
+	}
+}
+
+// TestShowCmdProfileSelectorJSONSource verifies that JSON output exposes
+// the source field when a profile is selected via --profile.
+func TestShowCmdProfileSelectorJSONSource(t *testing.T) {
+	configDir := setupTestConfigDir(t)
+
+	testProfiles := []profiles.Profile{
+		{
+			Name: "prod",
+			Configuration: profiles.Configuration{
+				ApiUrl:    "https://api-prod.example.com",
+				AuthToken: "prod_token",
+			},
+		},
+	}
+	createTestProfilesFile(t, configDir, testProfiles)
+	setActiveProfile(t, configDir, "prod")
+
+	ctx := WithProfileSelector(context.Background(), ProfileSelector{
+		Name:   "prod",
+		Source: ProfileSourceFlag,
+	})
+
+	rootCmd := &cobra.Command{Use: "dash0"}
+	rootCmd.AddCommand(NewConfigCmd())
+
+	output, err := executeCommandWithContext(ctx, rootCmd, "config", "show", "-o", "json")
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	var parsed configShowJSON
+	if err := json.Unmarshal([]byte(output), &parsed); err != nil {
+		t.Fatalf("Failed to parse JSON output: %v\nOutput: %s", err, output)
+	}
+
+	if parsed.Profile == nil {
+		t.Fatal("Expected profile field in JSON output")
+	}
+	if parsed.Profile.Value != "prod" {
+		t.Errorf("Expected profile value 'prod', got %q", parsed.Profile.Value)
+	}
+	if parsed.Profile.Source != "flag:--profile" {
+		t.Errorf("Expected profile source 'flag:--profile', got %q", parsed.Profile.Source)
+	}
+}
+
+// TestShowCmdNoSelectorNoAnnotation verifies that the Profile line is not
+// annotated when no selector is set, preserving existing behavior.
+func TestShowCmdNoSelectorNoAnnotation(t *testing.T) {
+	configDir := setupTestConfigDir(t)
+
+	testProfiles := []profiles.Profile{
+		{
+			Name: "dev",
+			Configuration: profiles.Configuration{
+				ApiUrl:    "https://api-dev.example.com",
+				AuthToken: "dev_token",
+			},
+		},
+	}
+	createTestProfilesFile(t, configDir, testProfiles)
+	setActiveProfile(t, configDir, "dev")
+
+	rootCmd := &cobra.Command{Use: "dash0"}
+	rootCmd.AddCommand(NewConfigCmd())
+
+	output, err := executeCommand(rootCmd, "config", "show")
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+
+	if bytes.Contains([]byte(output), []byte("(from --profile")) ||
+		bytes.Contains([]byte(output), []byte("(from DASH0_PROFILE")) {
+		t.Errorf("Did not expect profile source annotation, got:\n%s", output)
+	}
+	if !bytes.Contains([]byte(output), []byte("Profile:    dev\n")) {
+		t.Errorf("Expected unannotated Profile: dev line, got:\n%s", output)
 	}
 }

--- a/internal/config/profile_selector.go
+++ b/internal/config/profile_selector.go
@@ -1,0 +1,146 @@
+package config
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+
+	"github.com/dash0hq/dash0-api-client-go/profiles"
+)
+
+// EnvProfile is the environment variable that selects a named profile for the
+// current invocation, overriding the active profile recorded on disk.
+const EnvProfile = "DASH0_PROFILE"
+
+// ProfileSource identifies where an explicit profile selection came from.
+type ProfileSource int
+
+const (
+	// ProfileSourceNone indicates no explicit selection (the active profile is used).
+	ProfileSourceNone ProfileSource = iota
+	// ProfileSourceFlag indicates the selection came from the --profile flag.
+	ProfileSourceFlag
+	// ProfileSourceEnv indicates the selection came from the DASH0_PROFILE env var.
+	ProfileSourceEnv
+)
+
+// Description returns a human-readable source description suitable for
+// displaying in `config show` alongside a profile name.
+func (s ProfileSource) Description() string {
+	switch s {
+	case ProfileSourceFlag:
+		return "from --profile flag"
+	case ProfileSourceEnv:
+		return "from " + EnvProfile + " environment variable"
+	default:
+		return ""
+	}
+}
+
+// ProfileSelector records an explicit profile selection and its source.
+type ProfileSelector struct {
+	// Name is the explicit profile name. An empty string means the selector
+	// is absent and callers should use the active profile.
+	Name string
+	// Source identifies where the Name came from.
+	Source ProfileSource
+}
+
+// IsSet reports whether the selector has a non-empty explicit name.
+func (s ProfileSelector) IsSet() bool {
+	return s.Name != ""
+}
+
+// ResolveProfileSelector returns the explicit profile selector derived from
+// the --profile flag value and the DASH0_PROFILE environment variable.
+// Empty strings are treated as "not set" and fall through to the next
+// precedence step, which means the caller should use the active profile.
+func ResolveProfileSelector(flagValue string) ProfileSelector {
+	if flagValue != "" {
+		return ProfileSelector{Name: flagValue, Source: ProfileSourceFlag}
+	}
+	if envValue := os.Getenv(EnvProfile); envValue != "" {
+		return ProfileSelector{Name: envValue, Source: ProfileSourceEnv}
+	}
+	return ProfileSelector{}
+}
+
+type profileSelectorContextKey struct{}
+
+// WithProfileSelector returns a new context carrying the given selector.
+func WithProfileSelector(ctx context.Context, sel ProfileSelector) context.Context {
+	return context.WithValue(ctx, profileSelectorContextKey{}, sel)
+}
+
+// ProfileSelectorFromContext returns the selector stored in ctx, or an empty
+// selector if none is present.
+func ProfileSelectorFromContext(ctx context.Context) ProfileSelector {
+	sel, _ := ctx.Value(profileSelectorContextKey{}).(ProfileSelector)
+	return sel
+}
+
+// ResolveConfigurationForProfile loads the named profile from the store and
+// applies environment variable overrides on top.
+// It returns a "profile not found" error that lists the available profiles
+// when no profile with the given name exists.
+// When profileName is empty, callers should use the normal active-profile
+// resolution chain; this function only handles explicit selections.
+func ResolveConfigurationForProfile(profileName string) (*profiles.Configuration, error) {
+	if profileName == "" {
+		return nil, fmt.Errorf("profile name must not be empty")
+	}
+
+	store, err := profiles.NewStore()
+	if err != nil {
+		return nil, err
+	}
+
+	all, err := store.GetProfiles()
+	if err != nil {
+		return nil, err
+	}
+
+	if len(all) == 0 {
+		return nil, fmt.Errorf(
+			"profile %q does not exist; no profiles are configured.\nHint: create one with 'dash0 config profiles create'",
+			profileName,
+		)
+	}
+
+	var matched *profiles.Profile
+	names := make([]string, 0, len(all))
+	for i := range all {
+		names = append(names, all[i].Name)
+		if all[i].Name == profileName {
+			matched = &all[i]
+		}
+	}
+
+	if matched == nil {
+		sort.Strings(names)
+		return nil, fmt.Errorf(
+			"profile %q does not exist. Available profiles: %s",
+			profileName,
+			strings.Join(names, ", "),
+		)
+	}
+
+	cfg := matched.Configuration
+
+	if v := os.Getenv(profiles.EnvApiUrl); v != "" {
+		cfg.ApiUrl = v
+	}
+	if v := os.Getenv(profiles.EnvAuthToken); v != "" {
+		cfg.AuthToken = v
+	}
+	if v := os.Getenv(profiles.EnvOtlpUrl); v != "" {
+		cfg.OtlpUrl = v
+	}
+	if v := os.Getenv(profiles.EnvDataset); v != "" {
+		cfg.Dataset = v
+	}
+
+	return &cfg, nil
+}

--- a/internal/config/profile_selector_test.go
+++ b/internal/config/profile_selector_test.go
@@ -1,0 +1,200 @@
+package config
+
+import (
+	"context"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/dash0hq/dash0-api-client-go/profiles"
+)
+
+func TestResolveProfileSelector(t *testing.T) {
+	// Clean up env var leakage between cases.
+	original, originalSet := os.LookupEnv(EnvProfile)
+	t.Cleanup(func() {
+		if originalSet {
+			os.Setenv(EnvProfile, original)
+		} else {
+			os.Unsetenv(EnvProfile)
+		}
+	})
+
+	t.Run("flag takes precedence over env var", func(t *testing.T) {
+		os.Setenv(EnvProfile, "from-env")
+		defer os.Unsetenv(EnvProfile)
+
+		sel := ResolveProfileSelector("from-flag")
+		if !sel.IsSet() {
+			t.Fatal("selector should be set")
+		}
+		if sel.Name != "from-flag" {
+			t.Errorf("expected name 'from-flag', got %q", sel.Name)
+		}
+		if sel.Source != ProfileSourceFlag {
+			t.Errorf("expected source flag, got %v", sel.Source)
+		}
+	})
+
+	t.Run("env var used when flag is empty", func(t *testing.T) {
+		os.Setenv(EnvProfile, "from-env")
+		defer os.Unsetenv(EnvProfile)
+
+		sel := ResolveProfileSelector("")
+		if !sel.IsSet() {
+			t.Fatal("selector should be set")
+		}
+		if sel.Name != "from-env" {
+			t.Errorf("expected name 'from-env', got %q", sel.Name)
+		}
+		if sel.Source != ProfileSourceEnv {
+			t.Errorf("expected source env, got %v", sel.Source)
+		}
+	})
+
+	t.Run("empty flag and empty env var fall through", func(t *testing.T) {
+		os.Unsetenv(EnvProfile)
+
+		sel := ResolveProfileSelector("")
+		if sel.IsSet() {
+			t.Errorf("selector should not be set, got %+v", sel)
+		}
+		if sel.Source != ProfileSourceNone {
+			t.Errorf("expected source none, got %v", sel.Source)
+		}
+	})
+
+	t.Run("empty env var falls through", func(t *testing.T) {
+		os.Setenv(EnvProfile, "")
+		defer os.Unsetenv(EnvProfile)
+
+		sel := ResolveProfileSelector("")
+		if sel.IsSet() {
+			t.Errorf("selector should not be set, got %+v", sel)
+		}
+	})
+}
+
+func TestProfileSelectorContextRoundtrip(t *testing.T) {
+	sel := ProfileSelector{Name: "prod", Source: ProfileSourceFlag}
+	ctx := WithProfileSelector(context.Background(), sel)
+
+	got := ProfileSelectorFromContext(ctx)
+	if got != sel {
+		t.Errorf("roundtrip mismatch: want %+v, got %+v", sel, got)
+	}
+
+	empty := ProfileSelectorFromContext(context.Background())
+	if empty.IsSet() {
+		t.Errorf("empty context should return zero-value selector, got %+v", empty)
+	}
+}
+
+func TestProfileSourceDescription(t *testing.T) {
+	cases := []struct {
+		source ProfileSource
+		want   string
+	}{
+		{ProfileSourceNone, ""},
+		{ProfileSourceFlag, "from --profile flag"},
+		{ProfileSourceEnv, "from DASH0_PROFILE environment variable"},
+	}
+	for _, c := range cases {
+		if got := c.source.Description(); got != c.want {
+			t.Errorf("Description(%v) = %q, want %q", c.source, got, c.want)
+		}
+	}
+}
+
+func TestResolveConfigurationForProfile(t *testing.T) {
+	configDir := setupTestConfigDir(t)
+
+	testProfiles := []profiles.Profile{
+		{
+			Name: "dev",
+			Configuration: profiles.Configuration{
+				ApiUrl:    "https://api-dev.example.com",
+				AuthToken: "dev_auth_token",
+				OtlpUrl:   "https://otlp-dev.example.com",
+				Dataset:   "dev-ds",
+			},
+		},
+		{
+			Name: "prod",
+			Configuration: profiles.Configuration{
+				ApiUrl:    "https://api-prod.example.com",
+				AuthToken: "prod_auth_token",
+				Dataset:   "prod-ds",
+			},
+		},
+	}
+	createTestProfilesFile(t, configDir, testProfiles)
+	setActiveProfile(t, configDir, "dev")
+
+	t.Run("selected profile is used", func(t *testing.T) {
+		cfg, err := ResolveConfigurationForProfile("prod")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if cfg.ApiUrl != "https://api-prod.example.com" {
+			t.Errorf("expected prod api url, got %q", cfg.ApiUrl)
+		}
+		if cfg.Dataset != "prod-ds" {
+			t.Errorf("expected prod dataset, got %q", cfg.Dataset)
+		}
+	})
+
+	t.Run("env vars override individual fields", func(t *testing.T) {
+		os.Setenv(profiles.EnvDataset, "env-override-ds")
+		defer os.Unsetenv(profiles.EnvDataset)
+
+		cfg, err := ResolveConfigurationForProfile("prod")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if cfg.Dataset != "env-override-ds" {
+			t.Errorf("expected env override, got %q", cfg.Dataset)
+		}
+		// Other fields should still come from the profile.
+		if cfg.ApiUrl != "https://api-prod.example.com" {
+			t.Errorf("expected prod api url, got %q", cfg.ApiUrl)
+		}
+	})
+
+	t.Run("unknown profile returns error listing available profiles", func(t *testing.T) {
+		_, err := ResolveConfigurationForProfile("typo")
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+		msg := err.Error()
+		if !strings.Contains(msg, `profile "typo" does not exist`) {
+			t.Errorf("expected profile-not-exist error, got %q", msg)
+		}
+		if !strings.Contains(msg, "dev") || !strings.Contains(msg, "prod") {
+			t.Errorf("expected available profiles in error, got %q", msg)
+		}
+	})
+
+	t.Run("empty name is rejected", func(t *testing.T) {
+		_, err := ResolveConfigurationForProfile("")
+		if err == nil {
+			t.Fatal("expected error for empty name")
+		}
+	})
+}
+
+func TestResolveConfigurationForProfile_NoProfilesAtAll(t *testing.T) {
+	_ = setupTestConfigDir(t)
+
+	_, err := ResolveConfigurationForProfile("any")
+	if err == nil {
+		t.Fatal("expected error when no profiles are configured")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "no profiles are configured") {
+		t.Errorf("expected 'no profiles are configured' in error, got %q", msg)
+	}
+	if !strings.Contains(msg, "dash0 config profiles create") {
+		t.Errorf("expected hint in error, got %q", msg)
+	}
+}


### PR DESCRIPTION
Select a named profile for a single invocation without mutating the active profile on disk. Precedence: --profile flag → DASH0_PROFILE → active profile. A non-existent profile fails before any API call with a message listing the available profiles. config show annotates the Profile: line with the source when a selector is in effect.

Fixes #127