### PR TITLE
feat: add support for configuring retry attempts on throttling

### DIFF
--- a/.chloggen/max-retries-flag.yaml
+++ b/.chloggen/max-retries-flag.yaml
@@ -1,0 +1,29 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern (e.g. dashboards, config, apply)
+component: config
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Rename `DASH0_RETRY_COUNT` to `DASH0_MAX_RETRIES` and add `--max-retries` global flag
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [141]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  The environment variable `DASH0_RETRY_COUNT` has been renamed to `DASH0_MAX_RETRIES` for consistency with the Terraform provider.
+  A new `--max-retries` global flag is now available on all commands as an alternative to the environment variable.
+  Resolution order: `--max-retries` flag, then `DASH0_MAX_RETRIES` env var, then default (3).
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with "chore" or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Default: '[user]'
+change_logs: []

--- a/README.md
+++ b/README.md
@@ -411,6 +411,7 @@ dash0 -X api /api/organization/settings --dataset ""
 | `--file` | `-f` | | Input file path (use `-` for stdin) |
 | `--output` | `-o` | | Output format: `table`, `wide`, `json`, `yaml`, `csv` |
 | | | `DASH0_CONFIG_DIR` | Override the configuration directory (default: `~/.dash0`) |
+| `--max-retries` | | `DASH0_MAX_RETRIES` | Max retries for failed API requests (default: `3`, max: `5`; `0` to disable) |
 
 ### Output formats
 

--- a/cmd/dash0/main.go
+++ b/cmd/dash0/main.go
@@ -4,11 +4,13 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strconv"
 	"strings"
 
 	"github.com/dash0hq/dash0-api-client-go/profiles"
 	"github.com/dash0hq/dash0-cli/internal/agentmode"
 	"github.com/dash0hq/dash0-cli/internal/apply"
+	"github.com/dash0hq/dash0-cli/internal/client"
 	"github.com/dash0hq/dash0-cli/internal/checkrules"
 	dashcolor "github.com/dash0hq/dash0-cli/internal/color"
 	"github.com/dash0hq/dash0-cli/internal/config"
@@ -88,6 +90,7 @@ func init() {
 	rootCmd.PersistentFlags().String("color", "", `Color mode for output: "semantic" or "none" (env: DASH0_COLOR)`)
 	rootCmd.PersistentFlags().Bool("agent-mode", false, "Enable agent mode for AI coding agents (env: DASH0_AGENT_MODE)")
 	rootCmd.PersistentFlags().String("profile", "", "Profile to use for this invocation; overrides the active profile on disk (env: DASH0_PROFILE)")
+	rootCmd.PersistentFlags().String("max-retries", "", "Maximum number of retries for failed API requests (0-5; default: 3; env: DASH0_MAX_RETRIES)")
 }
 
 // newVersionCmd creates a new version command
@@ -245,6 +248,16 @@ func main() {
 		ctx = profiles.WithConfiguration(ctx, cfg)
 	}
 	ctx = config.WithProfileSelector(ctx, selector)
+
+	// Resolve --max-retries before cobra parses flags (same approach as --profile).
+	if raw := flagValue(os.Args[1:], "max-retries"); raw != "" {
+		v, err := strconv.Atoi(raw)
+		if err != nil {
+			printError(fmt.Errorf("invalid --max-retries value %q: must be an integer", raw))
+			os.Exit(1)
+		}
+		ctx = client.WithMaxRetries(ctx, &v)
+	}
 
 	if err := rootCmd.ExecuteContext(ctx); err != nil {
 		printError(err)

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -74,6 +74,7 @@ These flags are available on every command:
 | `--color` | | `DASH0_COLOR` | `semantic` (default) or `none` |
 | `--experimental` | `-X` | | Enable experimental commands |
 | | | `DASH0_CONFIG_DIR` | Override config directory (default: `~/.dash0`) |
+| `--max-retries` | | `DASH0_MAX_RETRIES` | Maximum number of retries for failed API requests (default: `3`, max: `5`; set to `0` to disable retries) |
 
 ### Agent mode
 

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -4,11 +4,18 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
+	"strconv"
 	"strings"
 
 	dash0api "github.com/dash0hq/dash0-api-client-go"
 	"github.com/dash0hq/dash0-api-client-go/profiles"
 	"github.com/dash0hq/dash0-cli/internal/version"
+)
+
+const (
+	// DefaultMaxRetries is the default number of retries for failed API requests.
+	DefaultMaxRetries = 3
 )
 
 // NewClientFromContext creates a new Dash0 API client using configuration from context.
@@ -33,10 +40,16 @@ func NewClientFromContext(ctx context.Context, apiUrl, authToken string) (dash0a
 		}
 	}
 
+	maxRetries, err := resolveMaxRetries(ctx)
+	if err != nil {
+		return nil, err
+	}
+
 	client, err := dash0api.NewClient(
 		dash0api.WithApiUrl(apiUrl),
 		dash0api.WithAuthToken(authToken),
 		dash0api.WithUserAgent(version.UserAgent()),
+		dash0api.WithMaxRetries(maxRetries),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create API client: %w", err)
@@ -71,10 +84,16 @@ func NewOtlpClientFromContext(ctx context.Context, otlpUrl, authToken string) (d
 		return nil, fmt.Errorf("auth-token is required; provide it as a flag, environment variable, or configure a profile")
 	}
 
+	maxRetries, err := resolveMaxRetries(ctx)
+	if err != nil {
+		return nil, err
+	}
+
 	client, err := dash0api.NewClient(
 		dash0api.WithOtlpEndpoint(dash0api.OtlpEncodingJson, finalOtlpUrl),
 		dash0api.WithAuthToken(finalAuthToken),
 		dash0api.WithUserAgent(version.UserAgent()),
+		dash0api.WithMaxRetries(maxRetries),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create OTLP client: %w", err)
@@ -94,6 +113,43 @@ func ResolveApiUrl(ctx context.Context, flagApiUrl string) string {
 		return cfg.ApiUrl
 	}
 	return ""
+}
+
+// resolveMaxRetries returns the maximum number of retries for API requests.
+// It checks (in order): the --max-retries flag from context, the
+// DASH0_MAX_RETRIES environment variable, then falls back to DefaultMaxRetries (3).
+func resolveMaxRetries(ctx context.Context) (int, error) {
+	// Check --max-retries flag from context (persistent flag on root command).
+	if cmd, ok := ctx.Value(maxRetriesCmdKey{}).(*int); ok && cmd != nil && *cmd >= 0 {
+		return validateMaxRetries(*cmd, "--max-retries flag")
+	}
+
+	raw := os.Getenv("DASH0_MAX_RETRIES")
+	if raw == "" {
+		return DefaultMaxRetries, nil
+	}
+	n, err := strconv.Atoi(raw)
+	if err != nil {
+		return 0, fmt.Errorf("invalid DASH0_MAX_RETRIES value %q: must be an integer", raw)
+	}
+	return validateMaxRetries(n, "DASH0_MAX_RETRIES")
+}
+
+func validateMaxRetries(n int, source string) (int, error) {
+	if n < 0 {
+		return 0, fmt.Errorf("invalid %s value %q: must not be negative", source, strconv.Itoa(n))
+	}
+	if n > dash0api.MaxRetries {
+		return 0, fmt.Errorf("invalid %s value %q: must not exceed %d", source, strconv.Itoa(n), dash0api.MaxRetries)
+	}
+	return n, nil
+}
+
+type maxRetriesCmdKey struct{}
+
+// WithMaxRetries stores the --max-retries flag value in the context.
+func WithMaxRetries(ctx context.Context, maxRetries *int) context.Context {
+	return context.WithValue(ctx, maxRetriesCmdKey{}, maxRetries)
 }
 
 // ErrorContext provides context about the asset involved in an error.

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -52,6 +52,83 @@ func TestNewClientFromContext_MissingConfig(t *testing.T) {
 	assert.Contains(t, err.Error(), "no active profile configured")
 }
 
+func TestResolveMaxRetries_Default(t *testing.T) {
+	t.Setenv("DASH0_MAX_RETRIES", "")
+	os.Unsetenv("DASH0_MAX_RETRIES")
+
+	n, err := resolveMaxRetries(context.Background())
+	assert.NoError(t, err)
+	assert.Equal(t, DefaultMaxRetries, n)
+}
+
+func TestResolveMaxRetries_FromEnv(t *testing.T) {
+	t.Setenv("DASH0_MAX_RETRIES", "2")
+
+	n, err := resolveMaxRetries(context.Background())
+	assert.NoError(t, err)
+	assert.Equal(t, 2, n)
+}
+
+func TestResolveMaxRetries_Zero(t *testing.T) {
+	t.Setenv("DASH0_MAX_RETRIES", "0")
+
+	n, err := resolveMaxRetries(context.Background())
+	assert.NoError(t, err)
+	assert.Equal(t, 0, n)
+}
+
+func TestResolveMaxRetries_InvalidNonInteger(t *testing.T) {
+	t.Setenv("DASH0_MAX_RETRIES", "abc")
+
+	_, err := resolveMaxRetries(context.Background())
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "must be an integer")
+}
+
+func TestResolveMaxRetries_Negative(t *testing.T) {
+	t.Setenv("DASH0_MAX_RETRIES", "-1")
+
+	_, err := resolveMaxRetries(context.Background())
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "must not be negative")
+}
+
+func TestResolveMaxRetries_ExceedsMax(t *testing.T) {
+	t.Setenv("DASH0_MAX_RETRIES", "10")
+
+	_, err := resolveMaxRetries(context.Background())
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "must not exceed")
+}
+
+func TestResolveMaxRetries_FlagTakesPrecedence(t *testing.T) {
+	t.Setenv("DASH0_MAX_RETRIES", "4")
+
+	flagValue := 1
+	ctx := WithMaxRetries(context.Background(), &flagValue)
+	n, err := resolveMaxRetries(ctx)
+	assert.NoError(t, err)
+	assert.Equal(t, 1, n)
+}
+
+func TestResolveMaxRetries_FlagZeroOverridesEnv(t *testing.T) {
+	t.Setenv("DASH0_MAX_RETRIES", "3")
+
+	flagValue := 0
+	ctx := WithMaxRetries(context.Background(), &flagValue)
+	n, err := resolveMaxRetries(ctx)
+	assert.NoError(t, err)
+	assert.Equal(t, 0, n)
+}
+
+func TestResolveMaxRetries_FlagExceedsMax(t *testing.T) {
+	flagValue := 10
+	ctx := WithMaxRetries(context.Background(), &flagValue)
+	_, err := resolveMaxRetries(ctx)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "must not exceed")
+}
+
 func TestResolveDataset_FlagTakesPrecedence(t *testing.T) {
 	cfg := &profiles.Configuration{
 		ApiUrl:    "https://api.test.dash0.com",

--- a/internal/client/retry_test.go
+++ b/internal/client/retry_test.go
@@ -1,0 +1,110 @@
+package client
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	dash0api "github.com/dash0hq/dash0-api-client-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// throttledServer returns a handler that responds with 429 for the first
+// failCount requests, then responds with 200 and a valid JSON body.
+func throttledServer(failCount int, requestCount *atomic.Int32) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := requestCount.Add(1)
+		if int(n) <= failCount {
+			w.Header().Set("Retry-After", "0")
+			w.WriteHeader(http.StatusTooManyRequests)
+			_, _ = w.Write([]byte(`{"message":"rate limited"}`))
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"kind":"Dashboard","metadata":{"name":"test"},"spec":{}}`))
+	})
+}
+
+func newTestClient(t *testing.T, serverURL string, maxRetries int) dash0api.Client {
+	t.Helper()
+	c, err := dash0api.NewClient(
+		dash0api.WithApiUrl(serverURL),
+		dash0api.WithAuthToken("auth_test-token-12345"),
+		dash0api.WithUserAgent("dash0-cli/test"),
+		dash0api.WithMaxRetries(maxRetries),
+		dash0api.WithRetryWaitMin(1*time.Millisecond),
+		dash0api.WithRetryWaitMax(5*time.Millisecond),
+	)
+	require.NoError(t, err)
+	return c
+}
+
+func TestRetry_SucceedsAfterTransientThrottling(t *testing.T) {
+	tests := []struct {
+		name       string
+		maxRetries int
+		failCount  int
+		wantOK     bool
+		wantTotal  int32
+	}{
+		{
+			name:       "succeeds on first attempt (no 429s)",
+			maxRetries: 3,
+			failCount:  0,
+			wantOK:     true,
+			wantTotal:  1,
+		},
+		{
+			name:       "succeeds after 1 retry",
+			maxRetries: 3,
+			failCount:  1,
+			wantOK:     true,
+			wantTotal:  2,
+		},
+		{
+			name:       "succeeds after all retries exhausted",
+			maxRetries: 3,
+			failCount:  3,
+			wantOK:     true,
+			wantTotal:  4, // 1 initial + 3 retries
+		},
+		{
+			name:       "fails when retries not enough",
+			maxRetries: 2,
+			failCount:  3,
+			wantOK:     false,
+			wantTotal:  3, // 1 initial + 2 retries, all got 429
+		},
+		{
+			name:       "no retries configured",
+			maxRetries: 0,
+			failCount:  1,
+			wantOK:     false,
+			wantTotal:  1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var requestCount atomic.Int32
+			server := httptest.NewServer(throttledServer(tt.failCount, &requestCount))
+			t.Cleanup(server.Close)
+
+			c := newTestClient(t, server.URL, tt.maxRetries)
+			_, err := c.GetDashboard(t.Context(), "test-id", nil)
+
+			if tt.wantOK {
+				require.NoError(t, err)
+			} else {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), fmt.Sprintf("%d", http.StatusTooManyRequests))
+			}
+			assert.Equal(t, tt.wantTotal, requestCount.Load())
+		})
+	}
+}


### PR DESCRIPTION
The Dash0 APIs return status code 429 with the `RetryAfter` header in relative form to signal to the provider to retry later. This change increases the default amount of retries from 1 to 3, and makes them configurable using the `--max-retries` global setting and the `DASH0_MAX_RETRIES` environment variable (max 5 retries).