### PR TITLE
fix: send-log-event action ignores connection inputs when a profile already exists

### DIFF
--- a/.chloggen/send-log-event-action-profile-update.yaml
+++ b/.chloggen/send-log-event-action-profile-update.yaml
@@ -1,0 +1,29 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern (e.g. dashboards, config, apply)
+component: send-log-event action
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix `send-log-event` action ignoring connection inputs when a profile already exists
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [143]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  When a profile already existed (e.g., from the setup action), the action skipped profile creation
+  and ignored any `otlp-url`, `auth-token`, or `dataset` inputs. The action now updates the existing
+  profile with the provided values.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with "chore" or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Default: '[user]'
+change_logs: []

--- a/.github/actions/send-log-event/action.yaml
+++ b/.github/actions/send-log-event/action.yaml
@@ -220,7 +220,7 @@ runs:
 
     # -- Ensure a profile exists --
 
-    - name: Create Dash0 profile if needed
+    - name: Create or update Dash0 profile
       shell: bash
       env:
         INPUT_OTLP_URL: ${{ inputs.otlp-url }}
@@ -229,20 +229,24 @@ runs:
       run: |
         export PATH="$HOME/.dash0/bin:$PATH"
 
-        # If an active profile already exists (e.g., from the setup action), skip creation.
-        # When no profile is configured, `dash0 config show` prints "Profile:    (none)".
-        PROFILE_LINE=$(dash0 config show 2>/dev/null | grep '^Profile:' || true)
-        if [ -n "$PROFILE_LINE" ] && ! echo "$PROFILE_LINE" | grep -q '(none)'; then
-          echo "Active profile found, skipping profile creation."
-          exit 0
-        fi
-
-        # No active profile — create one from the connection inputs.
         ARGS=()
         [ -n "$INPUT_OTLP_URL" ] && ARGS+=(--otlp-url "$INPUT_OTLP_URL")
         [ -n "$INPUT_AUTH_TOKEN" ] && ARGS+=(--auth-token "$INPUT_AUTH_TOKEN")
         [ -n "$INPUT_DATASET" ] && ARGS+=(--dataset "$INPUT_DATASET")
 
+        # If an active profile already exists (e.g., from the setup action),
+        # update it with any connection inputs provided to this action.
+        # When no profile is configured, `dash0 config show` prints "Profile:    (none)".
+        PROFILE_LINE=$(dash0 config show 2>/dev/null | grep '^Profile:' || true)
+        if [ -n "$PROFILE_LINE" ] && ! echo "$PROFILE_LINE" | grep -q '(none)'; then
+          if [ ${#ARGS[@]} -gt 0 ]; then
+            PROFILE_NAME=$(echo "$PROFILE_LINE" | sed 's/^Profile:[[:space:]]*//' | sed 's/[[:space:]]*(.*//')
+            dash0 config profiles update "$PROFILE_NAME" "${ARGS[@]}"
+          fi
+          exit 0
+        fi
+
+        # No active profile — create one from the connection inputs.
         if [ ${#ARGS[@]} -eq 0 ]; then
           echo "::error::No active profile and no connection inputs (otlp-url, auth-token) provided."
           exit 1

--- a/.github/workflows/test-send-log-event-action.yml
+++ b/.github/workflows/test-send-log-event-action.yml
@@ -71,6 +71,35 @@ jobs:
           AFTER_MTIME=$(stat -c %Y ~/.dash0/bin/dash0)
           [ "${{ steps.before.outputs.mtime }}" = "$AFTER_MTIME" ] || { echo "Error: binary was reinstalled"; exit 1; }
 
+  test-profile-update:
+    name: 'Updates existing profile with connection inputs'
+    if: github.repository == 'dash0hq/dash0-cli'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Setup Dash0 CLI with a dummy token
+        uses: ./.github/actions/setup
+        with:
+          version: '1.1.0'
+          cache: 'false'
+          otlp-url: ${{ vars.DASH0_OTLP_URL }}
+          auth-token: auth_this-token-is-intentionally-invalid
+
+      - name: Verify profile has the dummy token
+        run: |
+          dash0 config show | grep -q '...alid'
+
+      - name: Send log event with the real token
+        uses: ./.github/actions/send-log-event
+        with:
+          otlp-url: ${{ vars.DASH0_OTLP_URL }}
+          auth-token: ${{ secrets.DASH0_AUTH_TOKEN }}
+          dataset: ${{ vars.DASH0_DATASET }}
+          event-name: dash0.ci.test
+          body: 'Profile update test'
+          service-name: send-log-event-action-ci
+
   test-rejects-old-cli:
     name: 'Rejects CLI below minimum version'
     runs-on: ubuntu-latest


### PR DESCRIPTION
Closes #143 