### PR TITLE
ci: introduce dash0hq/sync-docs-action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,16 @@ jobs:
       - name: Run ShellCheck
         run: make lint-sh
 
+  sync-docs-to-website-dry-run:
+    # Drift guard: verify on every CI build that the transformations declared in
+    # `.github/workflows/sync-docs/transformations.yaml` still apply cleanly against
+    # the current dash0-cli docs. The real sync (dry-run: false) runs from
+    # `release.yml` after a release is published.
+    name: Synchronize docs with dash0.com/docs (dry-run)
+    uses: ./.github/workflows/sync-docs-to-website.yaml
+    with:
+      dry-run: true
+
   discover-roundtrip-tests:
     runs-on: ubuntu-latest
     if: github.event_name != 'pull_request' || (github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]')

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,3 +57,12 @@ jobs:
           args: release --clean --release-notes release-notes.md
         env:
           GITHUB_TOKEN: ${{ secrets.REPOSITORY_FULL_ACCESS_GITHUB_TOKEN }}
+
+  sync-docs-to-website:
+    name: Synchronize docs with dash0.com/docs
+    needs: goreleaser
+    uses: ./.github/workflows/sync-docs-to-website.yaml
+    with:
+      dry-run: false
+    secrets:
+      REPOSITORY_FULL_ACCESS_GITHUB_TOKEN: ${{ secrets.REPOSITORY_FULL_ACCESS_GITHUB_TOKEN }}

--- a/.github/workflows/sync-docs-to-website.yaml
+++ b/.github/workflows/sync-docs-to-website.yaml
@@ -1,0 +1,108 @@
+name: Synchronize docs to dash0.com/docs
+
+# Copies the user-facing dash0-cli documentation into the site that powers https://www.dash0.com/docs,
+# applying the transformations declared in `.github/workflows/sync-docs/transformations.yaml`, and
+# opens a pull request against the target repository (dash0hq/dash0-website).
+#
+# Two modes:
+#
+#   - dry-run (workflow_dispatch default): verify that the transformations still apply cleanly
+#     against the current docs. No secrets required. Useful as a drift guard from CI on every PR.
+#     Only steps 1-4 of the sync-docs-action composite (checkout, install, transform) are executed;
+#     the target-repo checkout and PR steps are skipped.
+#
+#   - full sync (workflow_call from a release workflow, or workflow_dispatch with dry-run unchecked):
+#     runs the sync-docs-action end-to-end and opens/updates a PR on dash0hq/dash0-website.
+#     Requires the REPOSITORY_FULL_ACCESS_GITHUB_TOKEN secret — a fine-grained PAT with
+#     `contents:write` and `pull-requests:write` on the target documentation repository.
+
+on:
+  workflow_dispatch:
+    inputs:
+      dry-run:
+        description: Only verify the transformations still apply cleanly; do not open a pull request.
+        type: boolean
+        default: true
+  workflow_call:
+    inputs:
+      dry-run:
+        description: Only verify the transformations still apply cleanly; do not open a pull request.
+        type: boolean
+        default: false
+    secrets:
+      REPOSITORY_FULL_ACCESS_GITHUB_TOKEN:
+        description: Fine-grained PAT with contents+pull-requests write on dash0hq/dash0-website. Only required when dry-run is false.
+        required: false
+
+# sync-docs-action v0.1.0 — https://github.com/dash0hq/sync-docs-action/releases/tag/v0.1.0
+env:
+  SYNC_DOCS_ACTION_REF: 143e4f35aa2dc2a75c968f78631b85a1b36d3c77
+
+jobs:
+  sync-docs:
+    name: Synchronize dash0-cli docs with dash0.com/docs
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: checkout dash0-cli
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      # Full-sync path: hand off to the shared composite action, which transforms the docs, checks
+      # out the target repository, and opens (or force-updates) a pull request.
+      - name: sync docs to dash0.com/docs
+        if: ${{ ! inputs.dry-run }}
+        uses: dash0hq/sync-docs-action@143e4f35aa2dc2a75c968f78631b85a1b36d3c77 # v0.1.0
+        with:
+          source-root: .github/workflows/sync-docs
+          transformations-file: transformations.yaml
+          target-github-token: ${{ secrets.REPOSITORY_FULL_ACCESS_GITHUB_TOKEN }}
+          pr-branch: sync-dash0-cli-docs
+          pr-title: 'docs: synchronize dash0-cli documentation'
+          pr-body: |
+            This PR synchronizes the content of the [dash0-cli](https://github.com/dash0hq/dash0-cli) documentation into the documentation on https://www.dash0.com/docs.
+
+      # Dry-run path: replicate the transformation-engine invocation from the composite action
+      # (steps 1-4) so drift between the docs and transformations.yaml surfaces on every PR without
+      # requiring the docs-website PAT. Kept intentionally close to the composite action's own
+      # steps so the two stay behaviourally equivalent.
+
+      - name: check out sync-docs-action (dry-run)
+        if: ${{ inputs.dry-run }}
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          repository: dash0hq/sync-docs-action
+          ref: ${{ env.SYNC_DOCS_ACTION_REF }}
+          path: .sync-docs-action
+
+      - name: set up Node.js (dry-run)
+        if: ${{ inputs.dry-run }}
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version-file: .sync-docs-action/.nvmrc
+
+      - name: set up pnpm (dry-run)
+        if: ${{ inputs.dry-run }}
+        uses: pnpm/action-setup@8912a9102ac27614460f54aedde9e1e7f9aec20d # v6.0.5
+        with:
+          package_json_file: .sync-docs-action/package.json
+          run_install: false
+
+      - name: install sync-docs-action dependencies (dry-run)
+        if: ${{ inputs.dry-run }}
+        working-directory: .sync-docs-action
+        run: pnpm install --frozen-lockfile
+
+      - name: apply doc transformations (dry-run)
+        if: ${{ inputs.dry-run }}
+        run: |
+          node .sync-docs-action/packages/transformation-engine/src/apply-transformations.ts \
+            .github/workflows/sync-docs \
+            .github/workflows/sync-docs/transformations.yaml \
+            "${RUNNER_TEMP}/transformed-docs"
+
+      - name: list transformed docs (dry-run)
+        if: ${{ inputs.dry-run }}
+        run: |
+          echo "Transformed documents:"
+          find "${RUNNER_TEMP}/transformed-docs" -type f | sort

--- a/.github/workflows/sync-docs/transformations.yaml
+++ b/.github/workflows/sync-docs/transformations.yaml
@@ -1,0 +1,53 @@
+# Transformations applied to the dash0-cli docs before they are copied into the Dash0 documentation
+# repository. See ../sync-docs-to-website.yaml for the workflow that consumes this file.
+#
+# This directory doubles as the `source-root` passed to `dash0hq/sync-docs-action`. It intentionally
+# does not contain a `docs/` subdirectory, so the action's "every docs/*.md must be declared"
+# invariant is not triggered by this repo's development-facing docs under /docs. The `source` paths
+# below therefore reach out of this directory with `../../../` to point at the user-facing files at
+# the repository root and under /docs.
+#
+# See https://github.com/dash0hq/sync-docs-action for the transformation-engine reference.
+
+common:
+  - description: strip the leading top-level heading (the frontmatter title replaces it)
+    type: replace-regex
+    find: '^# [^\n]*\n'
+    replace: ''
+
+files:
+  - source: ../../../README.md
+    target: dash0-cli/overview.md
+    title: Overview
+    description: The Dash0 CLI is a command-line interface for humans, agentic AIs, and CI/CD to interact with the Dash0 observability platform.
+    transformations:
+      - description: rewrite the setup action link to a stable GitHub URL
+        type: replace-regex
+        find: '\]\(\.github/actions/setup/action\.yaml\)'
+        replace: '](https://github.com/dash0hq/dash0-cli/blob/main/.github/actions/setup/action.yaml)'
+      - description: rewrite the send-log-event action link to a stable GitHub URL
+        type: replace-regex
+        find: '\]\(\.github/actions/send-log-event/action\.yaml\)'
+        replace: '](https://github.com/dash0hq/dash0-cli/blob/main/.github/actions/send-log-event/action.yaml)'
+      - description: rewrite CONTRIBUTING.md links to a stable GitHub URL (page is not synced)
+        type: replace-regex
+        find: '\]\(CONTRIBUTING\.md(#[^)]*)?\)'
+        replace: '](https://github.com/dash0hq/dash0-cli/blob/main/CONTRIBUTING.md\1)'
+      - description: rewrite the brew-tap-migration doc link to a stable GitHub URL (page is not synced)
+        type: replace-regex
+        find: '\]\(docs/brew-tap-migration-2026-06\.md\)'
+        replace: '](https://github.com/dash0hq/dash0-cli/blob/main/docs/brew-tap-migration-2026-06.md)'
+      - description: rewrite the nix examples link to a stable GitHub URL
+        type: replace-regex
+        find: '\]\(nix/examples/home-manager-vm\)'
+        replace: '](https://github.com/dash0hq/dash0-cli/tree/main/nix/examples/home-manager-vm)'
+
+  - source: ../../../docs/commands.md
+    target: dash0-cli/commands.md
+    title: Command reference
+    description: Full reference for every dash0 CLI command, with syntax, flags, expected outputs, and examples for AI agents and automation workflows.
+    transformations:
+      - description: rewrite the cross-reference to documentation.md (page is not synced)
+        type: replace-regex
+        find: '\]\(documentation\.md#code-blocks\)'
+        replace: '](https://github.com/dash0hq/dash0-cli/blob/main/docs/documentation.md#code-blocks)'


### PR DESCRIPTION
Wires [`dash0hq/sync-docs-action@v0.1.0`](https://github.com/dash0hq/sync-docs-action/releases/tag/v0.1.0) into this repo so the CLI's `README.md` and `docs/commands.md` flow into the source of `dash0.com/docs`.