### PR TITLE
ci: bump sync-docs-action to v0.2.0 and emit nav.json

### DIFF
--- a/.github/workflows/sync-docs-to-website.yaml
+++ b/.github/workflows/sync-docs-to-website.yaml
@@ -34,9 +34,9 @@ on:
         description: Fine-grained PAT with contents+pull-requests write on dash0hq/dash0-website. Only required when dry-run is false.
         required: false
 
-# sync-docs-action v0.1.0 — https://github.com/dash0hq/sync-docs-action/releases/tag/v0.1.0
+# sync-docs-action v0.2.0 — https://github.com/dash0hq/sync-docs-action/releases/tag/v0.2.0
 env:
-  SYNC_DOCS_ACTION_REF: 143e4f35aa2dc2a75c968f78631b85a1b36d3c77
+  SYNC_DOCS_ACTION_REF: 9c3d55819e9b8143e695f8f7d4b6e00189ba40a3
 
 jobs:
   sync-docs:
@@ -49,13 +49,13 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       # Full-sync path: hand off to the shared composite action, which transforms the docs, checks
-      # out the target repository, and opens (or force-updates) a pull request.
+      # out the target repository, and opens (or force-updates) a pull request. `source-root` and
+      # `transformations-file` inherit their defaults (`.` and
+      # `.github/workflows/sync-docs/transformations.yaml`).
       - name: sync docs to dash0.com/docs
         if: ${{ ! inputs.dry-run }}
-        uses: dash0hq/sync-docs-action@143e4f35aa2dc2a75c968f78631b85a1b36d3c77 # v0.1.0
+        uses: dash0hq/sync-docs-action@9c3d55819e9b8143e695f8f7d4b6e00189ba40a3 # v0.2.0
         with:
-          source-root: .github/workflows/sync-docs
-          transformations-file: transformations.yaml
           target-github-token: ${{ secrets.REPOSITORY_FULL_ACCESS_GITHUB_TOKEN }}
           pr-branch: sync-dash0-cli-docs
           pr-title: 'docs: synchronize dash0-cli documentation'
@@ -97,7 +97,7 @@ jobs:
         if: ${{ inputs.dry-run }}
         run: |
           node .sync-docs-action/packages/transformation-engine/src/apply-transformations.ts \
-            .github/workflows/sync-docs \
+            . \
             .github/workflows/sync-docs/transformations.yaml \
             "${RUNNER_TEMP}/transformed-docs"
 

--- a/.github/workflows/sync-docs/transformations.yaml
+++ b/.github/workflows/sync-docs/transformations.yaml
@@ -26,6 +26,16 @@ nav:
   title: Tooling
 
 files:
+  - source: docs/about.md
+    target: dash0-cli/about.md
+    title: About the Dash0 CLI
+    description: Introduction to the Dash0 CLI — what it is, who it's for, and the design principles that shape its ergonomics for humans, AI agents, and CI/CD.
+
+  - source: docs/installation.md
+    target: dash0-cli/installation.md
+    title: Installation
+    description: Install the Dash0 CLI via Homebrew, GitHub Releases, Docker, Nix, or from source.
+
   - source: docs/commands.md
     target: dash0-cli/commands.md
     title: Command Reference

--- a/.github/workflows/sync-docs/transformations.yaml
+++ b/.github/workflows/sync-docs/transformations.yaml
@@ -26,32 +26,6 @@ nav:
   title: Tooling
 
 files:
-  - source: README.md
-    target: dash0-cli/overview.md
-    title: Overview
-    description: The Dash0 CLI is a command-line interface for humans, agentic AIs, and CI/CD to interact with the Dash0 observability platform.
-    transformations:
-      - description: rewrite the setup action link to a stable GitHub URL
-        type: replace-regex
-        find: '\]\(\.github/actions/setup/action\.yaml\)'
-        replace: '](https://github.com/dash0hq/dash0-cli/blob/main/.github/actions/setup/action.yaml)'
-      - description: rewrite the send-log-event action link to a stable GitHub URL
-        type: replace-regex
-        find: '\]\(\.github/actions/send-log-event/action\.yaml\)'
-        replace: '](https://github.com/dash0hq/dash0-cli/blob/main/.github/actions/send-log-event/action.yaml)'
-      - description: rewrite CONTRIBUTING.md links to a stable GitHub URL (page is not synced)
-        type: replace-regex
-        find: '\]\(CONTRIBUTING\.md(#[^)]*)?\)'
-        replace: '](https://github.com/dash0hq/dash0-cli/blob/main/CONTRIBUTING.md\1)'
-      - description: rewrite the brew-tap-migration doc link to a stable GitHub URL (page is not synced)
-        type: replace-regex
-        find: '\]\(docs/brew-tap-migration-2026-06\.md\)'
-        replace: '](https://github.com/dash0hq/dash0-cli/blob/main/docs/brew-tap-migration-2026-06.md)'
-      - description: rewrite the nix examples link to a stable GitHub URL
-        type: replace-regex
-        find: '\]\(nix/examples/home-manager-vm\)'
-        replace: '](https://github.com/dash0hq/dash0-cli/tree/main/nix/examples/home-manager-vm)'
-
   - source: docs/commands.md
     target: dash0-cli/commands.md
     title: Command Reference
@@ -61,3 +35,27 @@ files:
         type: replace-regex
         find: '\]\(documentation\.md#code-blocks\)'
         replace: '](https://github.com/dash0hq/dash0-cli/blob/main/docs/documentation.md#code-blocks)'
+
+  - source: docs/github-actions.md
+    target: dash0-cli/github-actions.md
+    title: GitHub Actions
+    description: How to use the dash0 CLI from GitHub Actions workflows via the setup and send-log-event composite actions shipped in this repository.
+    transformations:
+      - description: rewrite the setup action link to a stable GitHub URL
+        type: replace-regex
+        find: '\]\(\.github/actions/setup/action\.yaml\)'
+        replace: '](https://github.com/dash0hq/dash0-cli/blob/main/.github/actions/setup/action.yaml)'
+      - description: rewrite the send-log-event action link to a stable GitHub URL
+        type: replace-regex
+        find: '\]\(\.github/actions/send-log-event/action\.yaml\)'
+        replace: '](https://github.com/dash0hq/dash0-cli/blob/main/.github/actions/send-log-event/action.yaml)'
+
+  - source: docs/brew-tap-migration-2026-06.md
+    target: dash0-cli/brew-tap-migration-2026-06.md
+    title: Homebrew Tap Migration (June 2026)
+    description: One-time migration notice for users who installed the Dash0 CLI from the legacy Homebrew formula before it moved to the qualified dash0hq/dash0-cli/dash0 cask.
+    transformations:
+      - description: rewrite the setup action README link to a stable GitHub URL
+        type: replace-regex
+        find: '\]\(\.\./\.github/actions/setup/README\.md\)'
+        replace: '](https://github.com/dash0hq/dash0-cli/blob/main/.github/actions/setup/README.md)'

--- a/.github/workflows/sync-docs/transformations.yaml
+++ b/.github/workflows/sync-docs/transformations.yaml
@@ -1,11 +1,14 @@
 # Transformations applied to the dash0-cli docs before they are copied into the Dash0 documentation
 # repository. See ../sync-docs-to-website.yaml for the workflow that consumes this file.
 #
-# This directory doubles as the `source-root` passed to `dash0hq/sync-docs-action`. It intentionally
-# does not contain a `docs/` subdirectory, so the action's "every docs/*.md must be declared"
-# invariant is not triggered by this repo's development-facing docs under /docs. The `source` paths
-# below therefore reach out of this directory with `../../../` to point at the user-facing files at
-# the repository root and under /docs.
+# `files:` is the sole opt-in list — the sync ignores anything in the source repo that is not
+# declared here (docs-coverage enforcement was removed in sync-docs-action v0.2.0).
+#
+# The `nav:` block emits a matching nav.json alongside the synced pages. sync-docs-action's nav
+# generator only produces the flat "one group, N file leaves" shape today, so a target tree of the
+# form `Miscellaneous → Tooling → Dash0 CLI → files` collapses to a single group. We name the group
+# "Tooling" so the CLI docs slot into whichever "Tooling" umbrella dash0-website already exposes
+# (or grows), rather than living under a standalone "Dash0 CLI" section.
 #
 # See https://github.com/dash0hq/sync-docs-action for the transformation-engine reference.
 
@@ -15,8 +18,15 @@ common:
     find: '^# [^\n]*\n'
     replace: ''
 
+nav:
+  target: dash0-cli/nav.json
+  order: 72.5
+  id: tooling
+  parentPath: Miscellaneous
+  title: Tooling
+
 files:
-  - source: ../../../README.md
+  - source: README.md
     target: dash0-cli/overview.md
     title: Overview
     description: The Dash0 CLI is a command-line interface for humans, agentic AIs, and CI/CD to interact with the Dash0 observability platform.
@@ -42,9 +52,9 @@ files:
         find: '\]\(nix/examples/home-manager-vm\)'
         replace: '](https://github.com/dash0hq/dash0-cli/tree/main/nix/examples/home-manager-vm)'
 
-  - source: ../../../docs/commands.md
+  - source: docs/commands.md
     target: dash0-cli/commands.md
-    title: Command reference
+    title: Command Reference
     description: Full reference for every dash0 CLI command, with syntax, flags, expected outputs, and examples for AI agents and automation workflows.
     transformations:
       - description: rewrite the cross-reference to documentation.md (page is not synced)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,6 +32,9 @@ Detailed guidelines are split into focused documents:
 - **Adding support for an asset type (or a new schema version of an existing one)  must follow @docs/adding-commands.md and @docs/cli-naming-conventions.md in full.**
   That document is the authoritative checklist: every numbered step and every requirement are required, not optional.
 
+- **When editing @README.md's top-of-file positioning or its Installation section, mirror the changes into @docs/about.md or @docs/installation.md respectively (and vice versa).**
+  Both docs are synced to dash0.com/docs on every release — drift ships as stale website content. See the "Docs synced to dash0.com/docs" section of @docs/documentation.md for the specifics.
+
 ## Key Dash0 API concepts
 
 ### Origin vs ID

--- a/docs/about.md
+++ b/docs/about.md
@@ -1,0 +1,40 @@
+# About the Dash0 CLI
+
+The Dash0 CLI (`dash0`) is a command-line interface for the [Dash0](https://www.dash0.com) observability platform.
+It exposes the same primitives as the web UI — dashboards, views, check rules, synthetic checks, teams, notification channels — plus telemetry queries and OTLP send operations, as commands that humans, agentic AIs, and CI/CD workflows can drive.
+
+## Who it's for
+
+- **Humans** managing Dash0 assets and querying telemetry from the terminal.
+- **AI coding agents** (Claude Code, Cursor, Codex, Copilot, and others) that need discoverable, structured commands with predictable output.
+  Every command supports JSON output, structured `--help`, and JSON error formatting.
+  Agent mode makes those defaults automatic when the CLI detects an agent in the environment.
+- **CI/CD pipelines** that keep dashboards, rules, and other assets in sync with git via GitOps-style `apply`, or emit deployment events at release time.
+
+## What it does
+
+- **Manage assets as code.**
+  Create, list, get, update, and delete dashboards, views, check rules, recording rules, synthetic checks, notification channels, and spam filters — one command at a time or via `dash0 apply -f <dir>` for GitOps flows.
+- **Query telemetry.**
+  Search logs, spans, traces, metrics, and failed checks with a common filter syntax and time-range flags.
+- **Send telemetry.**
+  Emit logs, spans, and deployment events via OTLP directly from your terminal or from GitHub Actions.
+- **Manage profiles.**
+  Configure multiple Dash0 environments (development, staging, production, or several organizations) with named profiles and either OAuth or static-token authentication.
+
+## Design principles
+
+- **Ergonomic for agents by default.**
+  Structured JSON output, JSON help, JSON errors, no interactive prompts, no colored output — all triggered automatically when the CLI is invoked by a known AI coding agent.
+- **Consistent surface across asset types.**
+  Every asset kind uses the same five subcommands (`list`, `get`, `create`, `update`, `delete`), the same output formats (`table`, `wide`, `json`, `yaml`, `csv`), and the same idempotent-upsert semantics.
+- **Idempotent by design.**
+  `apply` and per-asset `create` perform create-or-replace (PUT) when the source document carries a user-defined identifier — safe to run repeatedly from CI.
+- **No secrets on the command line.**
+  Authentication and connection settings live in profiles or environment variables; the CLI never asks for a token as a positional argument.
+
+## Next steps
+
+- [Installation](installation.md) — install via Homebrew, Docker, Nix, or from source.
+- [Command Reference](commands.md) — full syntax and examples for every command.
+- [GitHub Actions](github-actions.md) — use the CLI from your workflows.

--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -17,6 +17,24 @@ The valid values for `otel.log.severity.range` are: TRACE, DEBUG, INFO, WARN, ER
 
 For metrics commands, note that PromQL examples use Prometheus-style names (underscores, e.g., `service_name`, `http_server_request_duration_seconds`), while `--filter` examples use OTel-style names (dots, e.g., `service.name`) which are normalized to Prometheus labels automatically.
 
+## Docs synced to dash0.com/docs
+
+The `sync-docs-to-website` workflow (`.github/workflows/sync-docs-to-website.yaml`) copies a subset of the user-facing docs into `dash0hq/dash0-website` on every release.
+Sources are declared in `.github/workflows/sync-docs/transformations.yaml`.
+
+Currently synced: `docs/about.md`, `docs/installation.md`, `docs/commands.md`, `docs/github-actions.md`, `docs/brew-tap-migration-2026-06.md`.
+
+### Keep `docs/about.md` and `docs/installation.md` in sync with @README.md
+
+`docs/about.md` and `docs/installation.md` overlap with @README.md on purpose: the README stays the canonical GitHub landing page, and these two docs are what dash0.com/docs actually renders under the CLI section.
+
+- Changes to the top of @README.md (the description and the "An ergonomic CLI for agentic AI" section) must be mirrored into `docs/about.md`.
+- Changes to @README.md's Installation section (adding or dropping an install channel, updating versions, updating example commands) must be mirrored into `docs/installation.md`.
+- The reverse also holds: any change to `docs/about.md` or `docs/installation.md` that is not purely website-specific should be reflected in @README.md.
+
+The two docs are intentionally leaner than @README.md.
+Details that only matter to contributors reading the repo (for example the full Home Manager module example, `nix develop`, or the `make install` recipe) stay in @README.md and are linked out from `docs/installation.md` rather than duplicated.
+
 ## Environment Variables Reference Table
 The README contains an "Environment Variables" table listing all supported env vars.
 When adding a new environment variable (e.g., for a new config field), add a row to this table.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,0 +1,65 @@
+# Installation
+
+The Dash0 CLI is available for macOS, Linux, and Windows through multiple channels.
+
+## Homebrew (macOS and Linux)
+
+```bash
+brew install --cask dash0hq/dash0-cli/dash0
+```
+
+No `brew tap` or extra ceremony required — the qualified install path taps the [`dash0hq/homebrew-dash0-cli`](https://github.com/dash0hq/homebrew-dash0-cli) repository on first use.
+
+> [!NOTE]
+> If you previously installed `dash0` from the legacy formula (`brew install dash0` after `brew tap dash0hq/dash0-cli <URL>`), see the [Homebrew Tap Migration (June 2026)](brew-tap-migration-2026-06.md) for the one-time switch to the new cask.
+
+## GitHub Releases
+
+Download pre-built binaries for your platform from the [releases page](https://github.com/dash0hq/dash0-cli/releases).
+Archives are available for Linux, macOS, and Windows across multiple architectures.
+
+## Docker
+
+```bash
+docker run ghcr.io/dash0hq/cli:latest [command]
+```
+
+Multi-architecture images (`linux/amd64`, `linux/arm64`) are published to the GitHub Container Registry.
+
+## Nix / NixOS
+
+The repository is published as a Nix flake.
+
+Run without installing:
+
+```bash
+nix run github:dash0hq/dash0-cli -- dashboards list
+```
+
+Install into your Nix profile:
+
+```bash
+nix profile install github:dash0hq/dash0-cli
+```
+
+A pre-built binary is also published to the Dash0 Nix User Repository (NUR), which skips compilation and is useful on small or non-`x86_64` machines:
+
+```bash
+nix profile install github:dash0hq/nur#dash0
+```
+
+For Home Manager integration with declarative Dash0 profiles, and for consuming the flake's `overlays.default` from a NixOS or Home Manager configuration, see the [full Nix documentation on GitHub](https://github.com/dash0hq/dash0-cli/blob/main/README.md#nix--nixos).
+
+## From source
+
+Requires Go 1.22 or higher.
+
+```bash
+git clone https://github.com/dash0hq/dash0-cli.git
+cd dash0-cli
+make install
+```
+
+## GitHub Actions
+
+To use the CLI from GitHub Actions workflows, see the [GitHub Actions guide](github-actions.md).


### PR DESCRIPTION
Pins `dash0hq/sync-docs-action` to [v0.2.0](https://github.com/dash0hq/sync-docs-action/releases/tag/v0.2.0) (SHA `9c3d558`) and add more documentation pages