### PR TITLE
chore(docs): adopt sync-docs-action v0.3.0 and emit the nested nav

### DIFF
--- a/.github/workflows/sync-docs-to-website.yaml
+++ b/.github/workflows/sync-docs-to-website.yaml
@@ -34,9 +34,9 @@ on:
         description: Fine-grained PAT with contents+pull-requests write on dash0hq/dash0-website. Only required when dry-run is false.
         required: false
 
-# sync-docs-action v0.2.0 — https://github.com/dash0hq/sync-docs-action/releases/tag/v0.2.0
+# sync-docs-action v0.3.0 — https://github.com/dash0hq/sync-docs-action/releases/tag/v0.3.0
 env:
-  SYNC_DOCS_ACTION_REF: 9c3d55819e9b8143e695f8f7d4b6e00189ba40a3
+  SYNC_DOCS_ACTION_REF: de42352c0e212c770c6e91cf85993c7e76f5a8b9
 
 jobs:
   sync-docs:
@@ -54,7 +54,7 @@ jobs:
       # `.github/workflows/sync-docs/transformations.yaml`).
       - name: sync docs to dash0.com/docs
         if: ${{ ! inputs.dry-run }}
-        uses: dash0hq/sync-docs-action@9c3d55819e9b8143e695f8f7d4b6e00189ba40a3 # v0.2.0
+        uses: dash0hq/sync-docs-action@de42352c0e212c770c6e91cf85993c7e76f5a8b9 # v0.3.0
         with:
           target-github-token: ${{ secrets.REPOSITORY_FULL_ACCESS_GITHUB_TOKEN }}
           pr-branch: sync-dash0-cli-docs

--- a/.github/workflows/sync-docs/transformations.yaml
+++ b/.github/workflows/sync-docs/transformations.yaml
@@ -4,11 +4,12 @@
 # `files:` is the sole opt-in list — the sync ignores anything in the source repo that is not
 # declared here (docs-coverage enforcement was removed in sync-docs-action v0.2.0).
 #
-# The `nav:` block emits a matching nav.json alongside the synced pages. sync-docs-action's nav
-# generator only produces the flat "one group, N file leaves" shape today, so a target tree of the
-# form `Miscellaneous → Tooling → Dash0 CLI → files` collapses to a single group. We name the group
-# "Tooling" so the CLI docs slot into whichever "Tooling" umbrella dash0-website already exposes
-# (or grows), rather than living under a standalone "Dash0 CLI" section.
+# The `nav:` block emits a matching nav.json alongside the synced pages. sync-docs-action v0.3.0
+# derives the nav tree from the on-disk hierarchy of the `target` paths: files that share the
+# common directory prefix appear as top-level leaves under `items[0]`, and files that sit in a
+# deeper subdirectory (`github-actions/` here) are nested inside a `{ title, children }` group
+# whose title is looked up in `groupTitles`. The `dash0/miscellaneous/tooling/dash0-cli/` prefix in
+# every `target` matches the layout `dash0hq/dash0-website` renders under Miscellaneous → Tooling.
 #
 # See https://github.com/dash0hq/sync-docs-action for the transformation-engine reference.
 
@@ -19,30 +20,32 @@ common:
     replace: ''
 
 nav:
-  target: dash0-cli/nav.json
-  order: 72.5
-  id: tooling
-  parentPath: Miscellaneous
-  title: Tooling
+  target: dash0/miscellaneous/tooling/dash0-cli/nav.json
+  order: 72.6
+  id: dash0-cli
+  parentPath: Tooling
+  title: Dash0 CLI
+  groupTitles:
+    github-actions: GitHub Actions
 
 files:
   - source: docs/about.md
-    target: dash0-cli/about.md
+    target: dash0/miscellaneous/tooling/dash0-cli/about.md
     title: About the Dash0 CLI
     description: Introduction to the Dash0 CLI — what it is, who it's for, and the design principles that shape its ergonomics for humans, AI agents, and CI/CD.
 
   - source: docs/installation.md
-    target: dash0-cli/installation.md
+    target: dash0/miscellaneous/tooling/dash0-cli/installation.md
     title: Installation
     description: Install the Dash0 CLI via Homebrew, GitHub Releases, Docker, Nix, or from source.
 
   - source: docs/quickstart.md
-    target: dash0-cli/quickstart.md
+    target: dash0/miscellaneous/tooling/dash0-cli/quickstart.md
     title: Quickstart
     description: A five-minute walkthrough — log in, list assets, query telemetry, and send a deployment event.
 
   - source: docs/commands.md
-    target: dash0-cli/commands.md
+    target: dash0/miscellaneous/tooling/dash0-cli/commands.md
     title: Command Reference
     description: Full reference for every dash0 CLI command, with syntax, flags, expected outputs, and examples for AI agents and automation workflows.
     transformations:
@@ -52,21 +55,27 @@ files:
         replace: '](https://github.com/dash0hq/dash0-cli/blob/main/docs/documentation.md#code-blocks)'
 
   - source: docs/github-actions.md
-    target: dash0-cli/github-actions.md
-    title: GitHub Actions
+    target: dash0/miscellaneous/tooling/dash0-cli/github-actions/about.md
+    title: About GitHub Actions
     description: How to use the dash0 CLI from GitHub Actions workflows via the setup and send-log-event composite actions shipped in this repository.
+
+  - source: .github/actions/setup/README.md
+    target: dash0/miscellaneous/tooling/dash0-cli/github-actions/setup.md
+    title: Setup Dash0 CLI
+    description: Composite GitHub Action that installs and configures the Dash0 CLI in CI workflows.
+
+  - source: .github/actions/send-log-event/README.md
+    target: dash0/miscellaneous/tooling/dash0-cli/github-actions/send-log-event.md
+    title: Send Log Event
+    description: Composite GitHub Action that emits a log event (e.g., a deployment marker) to Dash0 via the CLI.
     transformations:
-      - description: rewrite the setup action link to a stable GitHub URL
+      - description: rewrite the "../setup/README.md" cross-action link to the sibling website page
         type: replace-regex
-        find: '\]\(\.github/actions/setup/action\.yaml\)'
-        replace: '](https://github.com/dash0hq/dash0-cli/blob/main/.github/actions/setup/action.yaml)'
-      - description: rewrite the send-log-event action link to a stable GitHub URL
-        type: replace-regex
-        find: '\]\(\.github/actions/send-log-event/action\.yaml\)'
-        replace: '](https://github.com/dash0hq/dash0-cli/blob/main/.github/actions/send-log-event/action.yaml)'
+        find: '\]\(\.\./setup/README\.md\)'
+        replace: '](setup.md)'
 
   - source: docs/brew-tap-migration-2026-06.md
-    target: dash0-cli/brew-tap-migration-2026-06.md
+    target: dash0/miscellaneous/tooling/dash0-cli/brew-tap-migration-2026-06.md
     title: Homebrew Tap Migration (June 2026)
     description: One-time migration notice for users who installed the Dash0 CLI from the legacy Homebrew formula before it moved to the qualified dash0hq/dash0-cli/dash0 cask.
     transformations:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,7 +24,7 @@ Detailed guidelines are split into focused documents:
 - @docs/project-structure.md — directory layout, package responsibilities
 - @docs/documentation.md — prose rules, attribute keys in examples, validation
 - @docs/testing.md — test strategies, integration tests, fixtures, mock server, roundtrip tests
-- @docs/github-actions.md — how to create GitHub actions based on the `dash0` CLI, existing actions and their maintenance
+- @docs/github-actions-maintenance.md — keeping the setup and send-log-event composite actions in sync with CLI changes, plus how the setup action is tested
 - @docs/changelog-maintenance.md — when and how to create changelog entries
 
 ## Hard rules

--- a/docs/github-actions-maintenance.md
+++ b/docs/github-actions-maintenance.md
@@ -1,0 +1,27 @@
+# Maintaining the GitHub Actions
+
+Repository-side notes on the two composite actions under `.github/actions/`.
+For the user-facing action documentation, see [github-actions.md](github-actions.md) and the sibling [setup/README.md](../.github/actions/setup/README.md) and [send-log-event/README.md](../.github/actions/send-log-event/README.md).
+
+## Keeping the actions in sync with CLI changes
+
+When modifying the logic of `dash0 config`, ensure that the [setup](../.github/actions/setup/action.yaml) GitHub Action is not affected negatively.
+Ensure that the constraints of `dash0 config profiles create` are enforced in the input validation of the setup GitHub action.
+
+When modifying the flags of `dash0 logs send`, ensure that the [send-log-event](../.github/actions/send-log-event/action.yaml) GitHub Action inputs stay in sync.
+
+## Testing the setup action
+
+The workflow `.github/workflows/test-setup-action.yml` runs on every pull request and on every push to `main` (not just changes to the action) because CLI changes — especially to `dash0 config profiles create` — can break the action's profile-creation step.
+Direct pushes to feature branches without an open PR do not trigger the workflow; open a (draft) PR to run it.
+The workflow can also be triggered manually via `workflow_dispatch`.
+
+The profile-creation tests mirror the parameter combinations tested in `TestCreateProfileCmdPartialFields` in `internal/config/config_cmd_test.go`.
+Each combination is a separate job that asserts the correct fields are set and the omitted fields show `(not set)` (or `default` for dataset).
+When adding or removing flags from `dash0 config profiles create`, update both the unit test and the workflow.
+
+## Keeping the action READMEs in sync with the website
+
+The two `README.md` files under `.github/actions/*/` are synced to `dash0.com/docs` as `Setup Dash0 CLI` and `Send Log Event` subpages under the `GitHub Actions` group.
+Edits to either README also affect the website on the next release; conversely, treat the README as the source of truth and update it whenever the action's inputs, outputs, or behavior change.
+See [`.github/workflows/sync-docs/transformations.yaml`](../.github/workflows/sync-docs/transformations.yaml) for the sync declarations.

--- a/docs/github-actions.md
+++ b/docs/github-actions.md
@@ -1,47 +1,9 @@
 # GitHub Actions
 
-GitHub Actions created around the `dash0` CLI are located under `.github/actions`, each action with a separate folder named after the action itself, e.g., the `Setup` action resides in `.github/actions`.
+The Dash0 CLI ships two composite GitHub Actions in this repository:
 
-## Setup Action
+- [`setup`](https://github.com/dash0hq/dash0-cli/tree/main/.github/actions/setup) — installs and configures the Dash0 CLI in CI workflows.
+- [`send-log-event`](https://github.com/dash0hq/dash0-cli/tree/main/.github/actions/send-log-event) — emits log events (typically deployment markers) to Dash0 via the CLI, without any bespoke shell scripting.
 
-The repository ships a composite GitHub Action at `.github/actions/setup/` that installs and configures the Dash0 CLI in CI workflows.
-Its documentation lives in `.github/actions/setup/README.md`.
-
-The minimum supported CLI version is 1.1.0.
-The action fails if a lower version is requested.
-
-The action:
-1. Resolves the CLI version (latest tag or user-specified) and enforces the minimum version.
-2. Downloads the Linux binary (`amd64` or `arm64`) from GitHub Releases.
-3. Caches the binary with `actions/cache` keyed on OS, arch, and version.
-4. Adds `~/.dash0/bin` to `$GITHUB_PATH`.
-5. Creates a `default` profile via `dash0 config profiles create` when any config input (`api-url`, `otlp-url`, `auth-token`, `dataset`) is provided.
-   All profile inputs are optional.
-6. Verifies the installation with `dash0 version` and `dash0 config show`.
-
-## Send Log Event Action
-
-The repository ships a composite GitHub Action at `.github/actions/send-log-event/` that sends a log event to Dash0.
-Its documentation lives in `.github/actions/send-log-event/README.md`.
-
-The action is standalone: it installs the Dash0 CLI automatically if not already on PATH, reusing the same install path and cache key as the setup action.
-It accepts connection parameters (`otlp-url`, `auth-token`, `dataset`) and all parameters supported by `dash0 logs send`.
-Recommended attributes from the [Dash0 deployment event spec](https://github.com/dash0hq/dash0-semantic-conventions) are exposed as first-level inputs (e.g., `service-name`, `deployment-status`).
-Additional attributes can be passed via `other-resource-attributes` and `other-log-attributes` as `key=value` pairs, one per line.
-
-## Keeping the actions in sync with CLI changes
-
-When modifying the logic of `dash0 config`, ensure that the [setup](.github/actions/setup/action.yaml) GitHub Action is not affected negatively.
-Ensure that the constraints of `dash0 config profiles create` are enforced in the input validation of the setup GitHub action.
-
-When modifying the flags of `dash0 logs send`, ensure that the [send-log-event](.github/actions/send-log-event/action.yaml) GitHub Action inputs stay in sync.
-
-## Testing the action
-
-The workflow `.github/workflows/test-setup-action.yml` runs on every pull request and on every push to `main` (not just changes to the action) because CLI changes — especially to `dash0 config profiles create` — can break the action's profile-creation step.
-Direct pushes to feature branches without an open PR do not trigger the workflow; open a (draft) PR to run it.
-The workflow can also be triggered manually via `workflow_dispatch`.
-
-The profile-creation tests mirror the parameter combinations tested in `TestCreateProfileCmdPartialFields` in `internal/config/config_cmd_test.go`.
-Each combination is a separate job that asserts the correct fields are set and the omitted fields show `(not set)` (or `default` for dataset).
-When adding or removing flags from `dash0 config profiles create`, update both the unit test and the workflow.
+Each action's full reference — inputs, outputs, and quick-start snippets — lives on its own page.
+For repository-side maintenance notes (how the actions stay in sync with CLI changes, how the setup action is tested), see [github-actions-maintenance.md](https://github.com/dash0hq/dash0-cli/blob/main/docs/github-actions-maintenance.md) on GitHub.


### PR DESCRIPTION
## Summary

- Pin the sync workflow to \`dash0hq/sync-docs-action@v0.3.0\` (SHA \`de42352\`).
- Re-add the \`nav:\` block; the v0.3.0 engine now derives the nested tree from \`target:\` paths, so the emitted \`nav.json\` matches the shape dash0-website currently maintains by hand.
- Retarget every file under \`dash0/miscellaneous/tooling/dash0-cli/\` so files land where dash0-website already renders them and the nav's \`path\` entries line up.
- Publish the two action READMEs (\`.github/actions/setup/README.md\`, \`.github/actions/send-log-event/README.md\`) as \`github-actions/setup.md\` and \`github-actions/send-log-event.md\`.
- Slim \`docs/github-actions.md\` to a 5-line landing (matches the site's existing \`github-actions/about.md\`). Contributor-side "keeping the actions in sync" and "testing the setup action" content moves into a new \`docs/github-actions-maintenance.md\` (not synced); CLAUDE.md's guidelines list is updated.