### PR TITLE
chore(tests): cover annotation preservation on check rules

### DIFF
--- a/internal/apply/integration_test.go
+++ b/internal/apply/integration_test.go
@@ -121,6 +121,72 @@ expression: up == 0
 	assert.Equal(t, "47b6ccbe-82ab-47c6-a613-ce0d7f34353e", *rule.Id)
 }
 
+func TestApply_CheckRule_PreservesAnnotations(t *testing.T) {
+	testutil.SetupTestEnv(t)
+
+	ruleID := "47b6ccbe-82ab-47c6-a613-ce0d7f34353e"
+	tmpDir := t.TempDir()
+	yamlFile := filepath.Join(tmpDir, "checkrule.yaml")
+	err := os.WriteFile(yamlFile, []byte(`kind: CheckRule
+id: 47b6ccbe-82ab-47c6-a613-ce0d7f34353e
+name: test-check-rule
+expression: up == 0
+annotations:
+  summary: Test summary
+  description: Test description
+  sharing: team:team_01abc
+labels:
+  dash0.com/origin: dash0-cli
+  team: platform
+`), 0644)
+	require.NoError(t, err)
+
+	server := testutil.NewMockServer(t, testutil.FixturesDir())
+	server.On(http.MethodGet, "/api/alerting/check-rules/"+ruleID, testutil.MockResponse{
+		StatusCode: http.StatusOK,
+		BodyFile:   testutil.FixtureCheckRulesImportSuccess,
+		Validator:  testutil.RequireHeaders,
+	})
+	server.WithCheckRulesUpdate(testutil.FixtureCheckRulesImportSuccess)
+
+	cmd := NewApplyCmd()
+	cmd.SetArgs([]string{"-f", yamlFile, "--api-url", server.URL, "--auth-token", testAuthToken})
+
+	var cmdErr error
+	testutil.CaptureStdout(t, func() {
+		cmdErr = cmd.Execute()
+	})
+
+	require.NoError(t, cmdErr)
+
+	// Verify user-settable annotations reach the server on PUT. The `sharing`
+	// annotation in particular is the payload the CLI ships and the backend is
+	// expected to honor on API-managed check rules — see INS-508 for the
+	// server-side silent-drop bug on UI/Terraform/operator-managed rules.
+	updateReq := findRequest(server.Requests(), http.MethodPut, apiPathCheckRules)
+	require.NotNil(t, updateReq, "expected an update request for check rule")
+
+	var rule dash0api.PrometheusAlertRule
+	require.NoError(t, json.Unmarshal(updateReq.Body, &rule))
+
+	require.NotNil(t, rule.Annotations)
+	require.NotNil(t, rule.Annotations.Sharing)
+	assert.Equal(t, "team:team_01abc", *rule.Annotations.Sharing)
+	require.NotNil(t, rule.Annotations.Summary)
+	assert.Equal(t, "Test summary", *rule.Annotations.Summary)
+	require.NotNil(t, rule.Annotations.Description)
+	assert.Equal(t, "Test description", *rule.Annotations.Description)
+
+	// Server-managed origin label is stripped; user-set labels survive.
+	require.NotNil(t, rule.Labels)
+	_, hasOrigin := (*rule.Labels)["dash0.com/origin"]
+	assert.False(t, hasOrigin, "dash0.com/origin label should be stripped")
+	assert.Equal(t, "platform", (*rule.Labels)["team"], "user-set labels should be preserved")
+
+	require.NotNil(t, rule.Id)
+	assert.Equal(t, ruleID, *rule.Id)
+}
+
 func TestApply_Dashboard_Created(t *testing.T) {
 	testutil.SetupTestEnv(t)
 

--- a/test/roundtrip/test_prometheus_rule_roundtrip.sh
+++ b/test/roundtrip/test_prometheus_rule_roundtrip.sh
@@ -15,6 +15,8 @@ GROUP_NAME=$(yq '.spec.groups[0].name' "$FIXTURE")
 # The CLI names check rules imported from a PrometheusRule CRD as
 # "<group name> - <alert name>", matching the operator and Terraform provider.
 EXPECTED_NAME="${GROUP_NAME} - ${ALERT_NAME}"
+EXPECTED_SUMMARY=$(yq '.spec.groups[0].rules[0].annotations.summary' "$FIXTURE")
+EXPECTED_DESCRIPTION=$(yq '.spec.groups[0].rules[0].annotations.description' "$FIXTURE")
 
 echo "=== PrometheusRule CRD round-trip test ==="
 echo "Expected check rule name: $EXPECTED_NAME"
@@ -57,17 +59,43 @@ fi
 echo "expression: $ACTUAL_EXPR"
 
 ACTUAL_SUMMARY=$(echo "$GET_JSON" | jq -r '.annotations.summary // empty')
-if [ -z "$ACTUAL_SUMMARY" ]; then
-  echo "FAIL: annotations.summary is empty (should be preserved from PrometheusRule annotations)"
+if [ "$ACTUAL_SUMMARY" != "$EXPECTED_SUMMARY" ]; then
+  echo "FAIL: expected annotations.summary '$EXPECTED_SUMMARY', got '$ACTUAL_SUMMARY'"
   exit 1
 fi
 echo "annotations.summary: $ACTUAL_SUMMARY"
+
+ACTUAL_DESCRIPTION=$(echo "$GET_JSON" | jq -r '.annotations.description // empty')
+if [ "$ACTUAL_DESCRIPTION" != "$EXPECTED_DESCRIPTION" ]; then
+  echo "FAIL: expected annotations.description '$EXPECTED_DESCRIPTION', got '$ACTUAL_DESCRIPTION'"
+  exit 1
+fi
+echo "annotations.description: $ACTUAL_DESCRIPTION"
 
 # Step 4: Export to YAML and re-import via apply (round-trip).
 echo "--- Step 4: Export and re-apply (round-trip) ---"
 "$DASH0" check-rules get "$ID" -o yaml > "${TMPDIR}/exported.yaml"
 REAPPLY_OUTPUT=$("$DASH0" apply -f "${TMPDIR}/exported.yaml")
 echo "$REAPPLY_OUTPUT"
+
+# Step 4a: Verify user-settable annotations survive the round-trip.
+# INS-508 tracks a backend bug where the check-rule PUT silently drops the
+# `sharing` annotation on non-API-managed rules; `summary` and `description`
+# are the fields the CLI can verify against a real backend without needing
+# a valid team id, so they act as the roundtrip guardrail here.
+echo "--- Step 4a: Verify annotations after round-trip ---"
+POST_ROUNDTRIP_JSON=$("$DASH0" check-rules get "$ID" -o json)
+POST_SUMMARY=$(echo "$POST_ROUNDTRIP_JSON" | jq -r '.annotations.summary // empty')
+if [ "$POST_SUMMARY" != "$EXPECTED_SUMMARY" ]; then
+  echo "FAIL: annotations.summary changed after round-trip: expected '$EXPECTED_SUMMARY', got '$POST_SUMMARY'"
+  exit 1
+fi
+POST_DESCRIPTION=$(echo "$POST_ROUNDTRIP_JSON" | jq -r '.annotations.description // empty')
+if [ "$POST_DESCRIPTION" != "$EXPECTED_DESCRIPTION" ]; then
+  echo "FAIL: annotations.description changed after round-trip: expected '$EXPECTED_DESCRIPTION', got '$POST_DESCRIPTION'"
+  exit 1
+fi
+echo "annotations survived round-trip: summary=$POST_SUMMARY, description=$POST_DESCRIPTION"
 
 # Step 5: Update via check-rules update with the CRD file (ID from argument).
 echo "--- Step 5: Update via check-rules update with CRD file (ID from arg) ---"


### PR DESCRIPTION
- Adds `TestApply_CheckRule_PreservesAnnotations` in `internal/apply/integration_test.go`. Asserts that `apply` sends the `sharing`, `summary`, and `description` annotations intact on PUT for native `CheckRule` documents, strips the server-managed `dash0.com/origin` label, and preserves user-set labels.
- Extends `test/roundtrip/test_prometheus_rule_roundtrip.sh` to verify both `annotations.summary` and `annotations.description` survive the export/re-apply cycle against a real backend (previously only `summary` presence was checked, non-empty).