### PR TITLE
chore: fix docs sync — GitHub Actions link + drop repo-maintenance pointer

### DIFF
--- a/.github/workflows/sync-docs/transformations.yaml
+++ b/.github/workflows/sync-docs/transformations.yaml
@@ -33,16 +33,31 @@ files:
     target: dash0/miscellaneous/tooling/dash0-cli/about.md
     title: About the Dash0 CLI
     description: Introduction to the Dash0 CLI — what it is, who it's for, and the design principles that shape its ergonomics for humans, AI agents, and CI/CD.
+    transformations:
+      - description: rewrite the GitHub Actions link to the nested sub-page (the source path collapses to a directory on the website)
+        type: replace-regex
+        find: '\]\(github-actions\.md\)'
+        replace: '](github-actions/about.md)'
 
   - source: docs/installation.md
     target: dash0/miscellaneous/tooling/dash0-cli/installation.md
     title: Installation
     description: Install the Dash0 CLI via Homebrew, GitHub Releases, Docker, Nix, or from source.
+    transformations:
+      - description: rewrite the GitHub Actions link to the nested sub-page (the source path collapses to a directory on the website)
+        type: replace-regex
+        find: '\]\(github-actions\.md\)'
+        replace: '](github-actions/about.md)'
 
   - source: docs/quickstart.md
     target: dash0/miscellaneous/tooling/dash0-cli/quickstart.md
     title: Quickstart
     description: A five-minute walkthrough — log in, list assets, query telemetry, and send a deployment event.
+    transformations:
+      - description: rewrite the GitHub Actions link to the nested sub-page (the source path collapses to a directory on the website)
+        type: replace-regex
+        find: '\]\(github-actions\.md\)'
+        replace: '](github-actions/about.md)'
 
   - source: docs/commands.md
     target: dash0/miscellaneous/tooling/dash0-cli/commands.md

--- a/docs/github-actions.md
+++ b/docs/github-actions.md
@@ -6,4 +6,3 @@ The Dash0 CLI ships two composite GitHub Actions in this repository:
 - [`send-log-event`](https://github.com/dash0hq/dash0-cli/tree/main/.github/actions/send-log-event) — emits log events (typically deployment markers) to Dash0 via the CLI, without any bespoke shell scripting.
 
 Each action's full reference — inputs, outputs, and quick-start snippets — lives on its own page.
-For repository-side maintenance notes (how the actions stay in sync with CLI changes, how the setup action is tested), see [github-actions-maintenance.md](https://github.com/dash0hq/dash0-cli/blob/main/docs/github-actions-maintenance.md) on GitHub.


### PR DESCRIPTION
Two corrections to the docs synced into `dash0hq/dash0-website`, after the recent move of `docs/github-actions.md` under a nested `github-actions/` group on the website:

- **Fix broken links (CI check-links failure).** `docs/about.md`, `docs/installation.md`, and `docs/quickstart.md` all link to `github-actions.md`. Since the sync now maps `docs/github-actions.md` → `github-actions/about.md`, that relative link resolves to `/docs/.../github-actions` on the website (no page) rather than `/docs/.../github-actions/about`. Added per-file `replace-regex` transformations that rewrite the link during sync. This resolves the check-links failure on [dash0-website PR #607](https://github.com/dash0hq/dash0-website/pull/607).
- **Drop the repo-maintenance pointer.** The last paragraph of `docs/github-actions.md` pointed at `docs/github-actions-maintenance.md`, which is contributor-facing content. Cursor Bugbot [flagged it](https://github.com/dash0hq/dash0-website/pull/607#discussion_r3604284120) as internal implementation detail leaking into customer docs. Deleting the paragraph from the source (rather than stripping it via a sync transformation) keeps the repo view and the website view identical, and avoids a fragile regex that would break on any future wording change. Contributors browsing `docs/` will still find `github-actions-maintenance.md` on their own — it sits right next to `github-actions.md`.