### PR TITLE
chore(docs): drop `.md` from the rewritten GitHub Actions link

### DIFF
--- a/.github/workflows/sync-docs/transformations.yaml
+++ b/.github/workflows/sync-docs/transformations.yaml
@@ -34,30 +34,30 @@ files:
     title: About the Dash0 CLI
     description: Introduction to the Dash0 CLI — what it is, who it's for, and the design principles that shape its ergonomics for humans, AI agents, and CI/CD.
     transformations:
-      - description: rewrite the GitHub Actions link to the nested sub-page (the source path collapses to a directory on the website)
+      - description: rewrite the GitHub Actions link to the nested sub-page (the source path collapses to a directory on the website; extension is dropped because the website serves pages at extensionless URLs and its link-checker rejects a trailing `.md`)
         type: replace-regex
         find: '\]\(github-actions\.md\)'
-        replace: '](github-actions/about.md)'
+        replace: '](github-actions/about)'
 
   - source: docs/installation.md
     target: dash0/miscellaneous/tooling/dash0-cli/installation.md
     title: Installation
     description: Install the Dash0 CLI via Homebrew, GitHub Releases, Docker, Nix, or from source.
     transformations:
-      - description: rewrite the GitHub Actions link to the nested sub-page (the source path collapses to a directory on the website)
+      - description: rewrite the GitHub Actions link to the nested sub-page (the source path collapses to a directory on the website; extension is dropped because the website serves pages at extensionless URLs and its link-checker rejects a trailing `.md`)
         type: replace-regex
         find: '\]\(github-actions\.md\)'
-        replace: '](github-actions/about.md)'
+        replace: '](github-actions/about)'
 
   - source: docs/quickstart.md
     target: dash0/miscellaneous/tooling/dash0-cli/quickstart.md
     title: Quickstart
     description: A five-minute walkthrough — log in, list assets, query telemetry, and send a deployment event.
     transformations:
-      - description: rewrite the GitHub Actions link to the nested sub-page (the source path collapses to a directory on the website)
+      - description: rewrite the GitHub Actions link to the nested sub-page (the source path collapses to a directory on the website; extension is dropped because the website serves pages at extensionless URLs and its link-checker rejects a trailing `.md`)
         type: replace-regex
         find: '\]\(github-actions\.md\)'
-        replace: '](github-actions/about.md)'
+        replace: '](github-actions/about)'
 
   - source: docs/commands.md
     target: dash0/miscellaneous/tooling/dash0-cli/commands.md


### PR DESCRIPTION
## Summary

Follow-up to `e2ed5a9` (which added the per-file `github-actions.md` → `github-actions/about.md` rewrite). Drop the `.md` extension from the replacement so it emits `github-actions/about` instead.

## Root cause

`sync-docs-action` has an automatic `.md`-stripping pass (`rewriteIntraDocsLinks`), but its regex only matches links whose target has no `/`. Our per-file replacement produces `github-actions/about.md` (with a `/`), so the auto-pass skips it and the `.md` survives all the way to the target file. `dash0-website`'s link-checker then rejects the trailing `.md` because the site serves pages at extension-less URLs.

Emitting `github-actions/about` directly (extension-less) matches the website's URL scheme and needs no downstream rewriting.

## Evidence

The failure surface is https://github.com/dash0hq/dash0-website/actions/runs/29597887662/job/87942625628?pr=607, where three links are flagged as broken:

- `about.md:43 — Link: github-actions/about.md`
- `installation.md:68 — Link: github-actions/about.md`
- `quickstart.md:83 — Link: github-actions/about.md`

After this change the same sync will emit `github-actions/about` on those three lines, which the link-checker accepts.