### PR TITLE
chore(docs): surface OAuth login upfront in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Dash0 CLI
 
 A command-line interface designed for humans, agentic AIs and CI/CD to interact with the [Dash0](https://www.dash0.com) observability platform.
+Humans authenticate interactively via OAuth 2.0 with `dash0 login`; CI/CD and agent workflows use static auth tokens — see the [quick start](#quick-start).
 
 ## An ergonomic CLI for agentic AI
 
@@ -10,6 +11,32 @@ Authentication and connection settings can be configured entirely through profil
 Commands use consistent naming conventions and flags.
 Structured and parseable output formats (`--output json`, `--output yaml`, `--output csv`).
 [Agent mode](#agent-mode) makes all of this automatic: JSON output, structured help, JSON errors, no prompts, and no colors — with zero configuration.
+
+## Quick start
+
+Install the CLI — Homebrew shown here, see [Installation](#installation) for all channels:
+
+```bash
+brew install --cask dash0hq/dash0-cli/dash0
+```
+
+Log in — no auth token needed:
+
+```bash
+# Find your api_url here: https://app.dash0.com/goto/settings/endpoints?endpoint_type=api_http
+dash0 login --profile default --api-url <api_url>
+```
+
+`dash0 login` creates the profile on first use, opens your browser to complete OAuth 2.0 with PKCE, and refreshes tokens automatically from then on.
+
+Run your first command:
+
+```bash
+dash0 dashboards list
+```
+
+In environments without a browser — CI runners, AI agent sessions — set `DASH0_AUTH_TOKEN` to a static [auth token](https://app.dash0.com/goto/settings/auth-tokens) instead of logging in.
+See the [quickstart walkthrough](docs/quickstart.md) for a five-minute tour from login to sending your first deployment event, and [Profiles](#profiles) for managing multiple environments.
 
 ## Installation
 
@@ -53,6 +80,8 @@ steps:
       DASH0_DATASET: my-dataset # Leave empty for the `default` dataset
     run: dash0 dashboards list
 ```
+
+Static auth tokens are the right fit for non-interactive environments like CI; on a workstation, prefer the browser-based OAuth flow via [`dash0 login`](#quick-start).
 
 #### Send Log Event Action
 

--- a/docs/about.md
+++ b/docs/about.md
@@ -2,6 +2,7 @@
 
 The Dash0 CLI (`dash0`) is a command-line interface for the [Dash0](https://www.dash0.com) observability platform.
 It exposes the same primitives as the web UI — dashboards, views, check rules, synthetic checks, teams, notification channels — plus telemetry queries and OTLP send operations, as commands that humans, agentic AIs, and CI/CD workflows can drive.
+Humans authenticate interactively via OAuth 2.0 with `dash0 login`; CI/CD and agent workflows use static auth tokens — see the [quickstart](quickstart.md).
 
 ## Who it's for
 
@@ -36,5 +37,6 @@ It exposes the same primitives as the web UI — dashboards, views, check rules,
 ## Next steps
 
 - [Installation](installation.md) — install via Homebrew, Docker, Nix, or from source.
+- [Quickstart](quickstart.md) — from login to your first commands in about five minutes.
 - [Command Reference](commands.md) — full syntax and examples for every command.
 - [GitHub Actions](github-actions.md) — use the CLI from your workflows.


### PR DESCRIPTION
## Why

The README documents OAuth 2.0 + PKCE login well, but only halfway down the page in the Profiles section. Everything a reader encounters before that — the intro and the GitHub Actions install example with `DASH0_AUTH_TOKEN` — mentions only static auth tokens, so a skimmer plausibly concludes the CLI is token-only.

## What

- Add a sentence to the opening description: OAuth via `dash0 login` for humans, static tokens for CI/CD and agents.
- Add a **Quick start** section right after the intro (install → `dash0 login` → `dash0 dashboards list`), condensed from [docs/quickstart.md](docs/quickstart.md) and linking to it for the full walkthrough.
- Add a one-line pointer to `dash0 login` next to the GitHub Actions `DASH0_AUTH_TOKEN` example.
- Mirror the description change into `docs/about.md` and add the quickstart to its next-steps list, per the mirroring rule in [docs/documentation.md](docs/documentation.md).

No command behavior changes; `dash0 login --profile default --api-url …` usage matches docs/quickstart.md and the `login` command help.