### PR TITLE
chore: transfer code ownership to @dash0hq/engineering-iac

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -8,4 +8,4 @@
 # "Require review from Code Owners" enabled.
 
 # Global owner — required reviewer for everything in the repository.
-* @mmanciop
+* @dash0hq/engineering-iac


### PR DESCRIPTION
## Summary

- Replaces the single-user code owner (`@mmanciop`) with the `@dash0hq/engineering-iac` team.
- Review requests are now routed to the team, and any team member can satisfy the required approval.

## Test plan

- [ ] Confirm `@dash0hq/engineering-iac` is auto-requested on the next PR opened by a non-team member.
- [ ] If Code Owner review is required on `main`, verify the required check still passes with a team-member approval.