### PR TITLE
chore(ci): skip action tests on release-only flake.nix bumps

### DIFF
--- a/.github/workflows/test-send-log-event-action.yml
+++ b/.github/workflows/test-send-log-event-action.yml
@@ -10,11 +10,13 @@ on:
       - 'Formula/**'
       - 'CHANGELOG.md'
       - .chloggen/**
+      - flake.nix
   pull_request:
     paths-ignore:
       - 'Formula/**'
       - 'CHANGELOG.md'
       - .chloggen/**
+      - flake.nix
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/test-setup-action.yml
+++ b/.github/workflows/test-setup-action.yml
@@ -10,11 +10,13 @@ on:
       - 'Formula/**'
       - 'CHANGELOG.md'
       - .chloggen/**
+      - flake.nix
   pull_request:
     paths-ignore:
       - 'Formula/**'
       - 'CHANGELOG.md'
       - .chloggen/**
+      - flake.nix
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## Summary

- Add `flake.nix` to `paths-ignore` on both `test-send-log-event-action.yml` and `test-setup-action.yml`, so release commits no longer trigger these workflows.

## Why

The two action-test workflows already try to skip release-only commits via `paths-ignore` for `Formula/**`, `CHANGELOG.md`, and `.chloggen/**`. But every release commit also bumps `flake.nix` (version + vendorHash), which was not in the list — so the workflows ran anyway and lost a race with the `Release` workflow:

- `resolve-cli-version.sh` resolves "latest" via `git ls-remote --tags`, which sees the release tag the moment it is pushed.
- The release assets (`dash0_<version>_<os>_<arch>.tar.gz`) are uploaded a few minutes later by the `Release` workflow.
- In between, `curl` for the tarball returns 404 and the action test job fails.

Concrete example: [run 29995090838](https://github.com/dash0hq/dash0-cli/actions/runs/29995090838), triggered by the `v1.16.0` release commit, failed in `Setup Dash0 CLI` because `https://github.com/dash0hq/dash0-cli/releases/download/v1.16.0/dash0_1.16.0_linux_amd64.tar.gz` didn't exist yet.