### PR TITLE
chore(docs,tests): pin apiVersion in asset YAML examples and cover error paths

### DIFF
--- a/.agents/skills/dash0-cli/references/check-rules.md
+++ b/.agents/skills/dash0-cli/references/check-rules.md
@@ -18,6 +18,7 @@
 Check rule:
 
 ```yaml
+apiVersion: dash0.com/v1alpha1
 kind: CheckRule
 id: b2c3d4e5-6789-01bc-def0-234567890abc
 name: High Error Rate

--- a/.agents/skills/dash0-cli/references/dashboards.md
+++ b/.agents/skills/dash0-cli/references/dashboards.md
@@ -18,6 +18,7 @@
 Dashboard:
 
 ```yaml
+apiVersion: dash0.com/v1alpha1
 kind: Dashboard
 metadata:
   name: a1b2c3d4-5678-90ab-cdef-1234567890ab

--- a/.agents/skills/dash0-cli/references/synthetic-checks.md
+++ b/.agents/skills/dash0-cli/references/synthetic-checks.md
@@ -18,6 +18,7 @@
 Synthetic check:
 
 ```yaml
+apiVersion: dash0.com/v1alpha1
 kind: SyntheticCheck
 metadata:
   name: API Health Check

--- a/.agents/skills/dash0-cli/references/views.md
+++ b/.agents/skills/dash0-cli/references/views.md
@@ -18,6 +18,7 @@
 View:
 
 ```yaml
+apiVersion: dash0.com/v1alpha1
 kind: View
 metadata:
   name: Error Logs

--- a/.claude/skills/dash0-cli/references/check-rules.md
+++ b/.claude/skills/dash0-cli/references/check-rules.md
@@ -18,6 +18,7 @@
 Check rule:
 
 ```yaml
+apiVersion: dash0.com/v1alpha1
 kind: CheckRule
 id: b2c3d4e5-6789-01bc-def0-234567890abc
 name: High Error Rate

--- a/.claude/skills/dash0-cli/references/dashboards.md
+++ b/.claude/skills/dash0-cli/references/dashboards.md
@@ -18,6 +18,7 @@
 Dashboard:
 
 ```yaml
+apiVersion: dash0.com/v1alpha1
 kind: Dashboard
 metadata:
   name: a1b2c3d4-5678-90ab-cdef-1234567890ab

--- a/.claude/skills/dash0-cli/references/synthetic-checks.md
+++ b/.claude/skills/dash0-cli/references/synthetic-checks.md
@@ -18,6 +18,7 @@
 Synthetic check:
 
 ```yaml
+apiVersion: dash0.com/v1alpha1
 kind: SyntheticCheck
 metadata:
   name: API Health Check

--- a/.claude/skills/dash0-cli/references/views.md
+++ b/.claude/skills/dash0-cli/references/views.md
@@ -18,6 +18,7 @@
 View:
 
 ```yaml
+apiVersion: dash0.com/v1alpha1
 kind: View
 metadata:
   name: Error Logs

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -804,6 +804,7 @@ Dry run: 1 document validated
 Dashboard:
 
 ```yaml
+apiVersion: dash0.com/v1alpha1
 kind: Dashboard
 metadata:
   name: a1b2c3d4-5678-90ab-cdef-1234567890ab
@@ -813,6 +814,8 @@ spec:
   display:
     name: Production Overview
 ```
+
+Pinning `apiVersion` on every user-authored file is a defense against silent migrations: today the server infers the default version when the field is omitted, but the same document with an explicit `apiVersion` will keep the same shape when a future default changes.
 
 The user-defined identifier lives in `metadata.dash0Extensions.id` (see [asset identifiers](#asset-identifiers-and-idempotent-upsert)).
 `metadata.name` is the CRD-style metadata name and is independent of `spec.display.name`, which is the title shown in the UI.
@@ -839,6 +842,7 @@ For PersesDashboards the user-defined identifier is the `dash0.com/id` metadata 
 Check rule:
 
 ```yaml
+apiVersion: dash0.com/v1alpha1
 kind: CheckRule
 id: b2c3d4e5-6789-01bc-def0-234567890abc
 name: High Error Rate
@@ -848,6 +852,7 @@ expression: sum(rate(http_requests_total{status=~"5.."}[5m])) > 0.1
 View:
 
 ```yaml
+apiVersion: dash0.com/v1alpha1
 kind: View
 metadata:
   name: Error Logs
@@ -860,6 +865,7 @@ spec:
 Synthetic check:
 
 ```yaml
+apiVersion: dash0.com/v1alpha1
 kind: SyntheticCheck
 metadata:
   name: API Health Check
@@ -931,6 +937,7 @@ The `delete` endpoint is version-agnostic.
 Notification channel (organization-level, no `--dataset`):
 
 ```yaml
+apiVersion: dash0.com/v1alpha1
 kind: Dash0NotificationChannel
 metadata:
   name: Slack Alerts
@@ -945,6 +952,7 @@ spec:
 Team (organization-level, no `--dataset`, requires `--experimental`):
 
 ```yaml
+apiVersion: dash0.com/v1alpha1
 kind: Dash0Team
 metadata:
   name: backend-team
@@ -991,6 +999,7 @@ The alerting rule is created as a check rule under `/api/alerting/check-rules`, 
 Multi-document file (separated by `---`):
 
 ```yaml
+apiVersion: dash0.com/v1alpha1
 kind: Dashboard
 metadata:
   name: e1f2a3b4-5678-90e5-6789-abcdef012345
@@ -998,6 +1007,7 @@ spec:
   display:
     name: First Dashboard
 ---
+apiVersion: dash0.com/v1alpha1
 kind: CheckRule
 id: f2a3b4c5-6789-01f6-7890-bcdef0123456
 name: Second Document Rule

--- a/internal/checkrules/integration_test.go
+++ b/internal/checkrules/integration_test.go
@@ -80,3 +80,71 @@ func TestListCheckRules_YAMLFormat(t *testing.T) {
 	assert.Contains(t, output, "name: Failing check rule 2")
 	assert.Contains(t, output, "expression:")
 }
+
+// TestGetCheckRule_NotFound pins the observable behavior when the server
+// returns 404 for a check rule GET: the error message must include "not found"
+// and name the asset type, so `dash0 check-rules get <id>` surfaces an
+// actionable message instead of a raw HTTP error.
+func TestGetCheckRule_NotFound(t *testing.T) {
+	testutil.SetupTestEnv(t)
+
+	server := testutil.NewMockServer(t, testutil.FixturesDir())
+	server.OnPattern(http.MethodGet, checkRuleIDPattern, testutil.MockResponse{
+		StatusCode: http.StatusNotFound,
+		BodyFile:   testutil.FixtureCheckRulesNotFound,
+		Validator:  testutil.RequireHeaders,
+	})
+
+	cmd := NewCheckRulesCmd()
+	cmd.SetArgs([]string{"get", "00000000-0000-0000-0000-000000000000", "--api-url", server.URL, "--auth-token", testAuthToken})
+
+	err := cmd.Execute()
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "check rule")
+	assert.Contains(t, err.Error(), "not found")
+}
+
+// TestGetCheckRule_Unauthorized pins the clean-message contract for 401.
+// The failure mode checklist requires that auth failures surface a message
+// that identifies the credential problem, not a raw 401 body.
+func TestGetCheckRule_Unauthorized(t *testing.T) {
+	testutil.SetupTestEnv(t)
+
+	server := testutil.NewMockServer(t, testutil.FixturesDir())
+	server.OnPattern(http.MethodGet, checkRuleIDPattern, testutil.MockResponse{
+		StatusCode: http.StatusUnauthorized,
+		BodyFile:   fixtureUnauthorized,
+		Validator:  testutil.RequireHeaders,
+	})
+
+	cmd := NewCheckRulesCmd()
+	cmd.SetArgs([]string{"get", "00000000-0000-0000-0000-000000000000", "--api-url", server.URL, "--auth-token", "auth_invalid"})
+
+	err := cmd.Execute()
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "authentication failed")
+}
+
+// TestDeleteCheckRule_NotFound covers the imperative delete path when
+// the server returns 404.
+func TestDeleteCheckRule_NotFound(t *testing.T) {
+	testutil.SetupTestEnv(t)
+
+	server := testutil.NewMockServer(t, testutil.FixturesDir())
+	server.OnPattern(http.MethodDelete, checkRuleIDPattern, testutil.MockResponse{
+		StatusCode: http.StatusNotFound,
+		BodyFile:   testutil.FixtureCheckRulesNotFound,
+		Validator:  testutil.RequireHeaders,
+	})
+
+	cmd := NewCheckRulesCmd()
+	cmd.SetArgs([]string{"delete", "00000000-0000-0000-0000-000000000000", "--force", "--api-url", server.URL, "--auth-token", testAuthToken})
+
+	err := cmd.Execute()
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "check rule")
+	assert.Contains(t, err.Error(), "not found")
+}

--- a/internal/recordingrules/integration_test.go
+++ b/internal/recordingrules/integration_test.go
@@ -219,6 +219,69 @@ func TestDeleteRecordingRule_Success(t *testing.T) {
 	assert.Contains(t, output, "deleted")
 }
 
+// TestGetRecordingRule_NotFound pins the clean-message contract on 404 GET.
+func TestGetRecordingRule_NotFound(t *testing.T) {
+	testutil.SetupTestEnv(t)
+
+	server := testutil.NewMockServer(t, testutil.FixturesDir())
+	server.OnPattern(http.MethodGet, recordingRuleIDPattern, testutil.MockResponse{
+		StatusCode: http.StatusNotFound,
+		BodyFile:   testutil.FixtureRecordingRulesNotFound,
+		Validator:  testutil.RequireHeaders,
+	})
+
+	cmd := NewRecordingRulesCmd()
+	cmd.SetArgs([]string{"get", "00000000-0000-0000-0000-000000000000", "--api-url", server.URL, "--auth-token", testAuthToken})
+
+	err := cmd.Execute()
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "recording rule")
+	assert.Contains(t, err.Error(), "not found")
+}
+
+// TestGetRecordingRule_Unauthorized pins the clean-message contract on 401.
+func TestGetRecordingRule_Unauthorized(t *testing.T) {
+	testutil.SetupTestEnv(t)
+
+	server := testutil.NewMockServer(t, testutil.FixturesDir())
+	server.OnPattern(http.MethodGet, recordingRuleIDPattern, testutil.MockResponse{
+		StatusCode: http.StatusUnauthorized,
+		BodyFile:   fixtureUnauthorized,
+		Validator:  testutil.RequireHeaders,
+	})
+
+	cmd := NewRecordingRulesCmd()
+	cmd.SetArgs([]string{"get", "00000000-0000-0000-0000-000000000000", "--api-url", server.URL, "--auth-token", "auth_invalid"})
+
+	err := cmd.Execute()
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "authentication failed")
+}
+
+// TestDeleteRecordingRule_NotFound covers the imperative delete path when
+// the server returns 404.
+func TestDeleteRecordingRule_NotFound(t *testing.T) {
+	testutil.SetupTestEnv(t)
+
+	server := testutil.NewMockServer(t, testutil.FixturesDir())
+	server.OnPattern(http.MethodDelete, recordingRuleIDPattern, testutil.MockResponse{
+		StatusCode: http.StatusNotFound,
+		BodyFile:   testutil.FixtureRecordingRulesNotFound,
+		Validator:  testutil.RequireHeaders,
+	})
+
+	cmd := NewRecordingRulesCmd()
+	cmd.SetArgs([]string{"delete", "00000000-0000-0000-0000-000000000000", "--force", "--api-url", server.URL, "--auth-token", testAuthToken})
+
+	err := cmd.Execute()
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "recording rule")
+	assert.Contains(t, err.Error(), "not found")
+}
+
 func TestListRecordingRules_DatasetQueryParam(t *testing.T) {
 	testutil.SetupTestEnv(t)
 

--- a/internal/skill/content/references/check-rules.md
+++ b/internal/skill/content/references/check-rules.md
@@ -18,6 +18,7 @@
 Check rule:
 
 ```yaml
+apiVersion: dash0.com/v1alpha1
 kind: CheckRule
 id: b2c3d4e5-6789-01bc-def0-234567890abc
 name: High Error Rate

--- a/internal/skill/content/references/dashboards.md
+++ b/internal/skill/content/references/dashboards.md
@@ -18,6 +18,7 @@
 Dashboard:
 
 ```yaml
+apiVersion: dash0.com/v1alpha1
 kind: Dashboard
 metadata:
   name: a1b2c3d4-5678-90ab-cdef-1234567890ab

--- a/internal/skill/content/references/synthetic-checks.md
+++ b/internal/skill/content/references/synthetic-checks.md
@@ -18,6 +18,7 @@
 Synthetic check:
 
 ```yaml
+apiVersion: dash0.com/v1alpha1
 kind: SyntheticCheck
 metadata:
   name: API Health Check

--- a/internal/skill/content/references/views.md
+++ b/internal/skill/content/references/views.md
@@ -18,6 +18,7 @@
 View:
 
 ```yaml
+apiVersion: dash0.com/v1alpha1
 kind: View
 metadata:
   name: Error Logs

--- a/internal/syntheticchecks/integration_test.go
+++ b/internal/syntheticchecks/integration_test.go
@@ -83,3 +83,67 @@ func TestListSyntheticChecks_YAMLFormat(t *testing.T) {
 	// Multiple documents should be separated by ---
 	assert.Contains(t, output, "---")
 }
+
+// TestGetSyntheticCheck_NotFound pins the clean-message contract on 404 GET.
+func TestGetSyntheticCheck_NotFound(t *testing.T) {
+	testutil.SetupTestEnv(t)
+
+	server := testutil.NewMockServer(t, testutil.FixturesDir())
+	server.OnPattern(http.MethodGet, syntheticCheckIDPattern, testutil.MockResponse{
+		StatusCode: http.StatusNotFound,
+		BodyFile:   testutil.FixtureSyntheticChecksNotFound,
+		Validator:  testutil.RequireHeaders,
+	})
+
+	cmd := NewSyntheticChecksCmd()
+	cmd.SetArgs([]string{"get", "00000000-0000-0000-0000-000000000000", "--api-url", server.URL, "--auth-token", testAuthToken})
+
+	err := cmd.Execute()
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "synthetic check")
+	assert.Contains(t, err.Error(), "not found")
+}
+
+// TestGetSyntheticCheck_Unauthorized pins the clean-message contract on 401.
+func TestGetSyntheticCheck_Unauthorized(t *testing.T) {
+	testutil.SetupTestEnv(t)
+
+	server := testutil.NewMockServer(t, testutil.FixturesDir())
+	server.OnPattern(http.MethodGet, syntheticCheckIDPattern, testutil.MockResponse{
+		StatusCode: http.StatusUnauthorized,
+		BodyFile:   fixtureUnauthorized,
+		Validator:  testutil.RequireHeaders,
+	})
+
+	cmd := NewSyntheticChecksCmd()
+	cmd.SetArgs([]string{"get", "00000000-0000-0000-0000-000000000000", "--api-url", server.URL, "--auth-token", "auth_invalid"})
+
+	err := cmd.Execute()
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "authentication failed")
+}
+
+// TestDeleteSyntheticCheck_NotFound covers the imperative delete path when
+// the server returns 404; the CLI must still exit non-zero with the same
+// clean message.
+func TestDeleteSyntheticCheck_NotFound(t *testing.T) {
+	testutil.SetupTestEnv(t)
+
+	server := testutil.NewMockServer(t, testutil.FixturesDir())
+	server.OnPattern(http.MethodDelete, syntheticCheckIDPattern, testutil.MockResponse{
+		StatusCode: http.StatusNotFound,
+		BodyFile:   testutil.FixtureSyntheticChecksNotFound,
+		Validator:  testutil.RequireHeaders,
+	})
+
+	cmd := NewSyntheticChecksCmd()
+	cmd.SetArgs([]string{"delete", "00000000-0000-0000-0000-000000000000", "--force", "--api-url", server.URL, "--auth-token", testAuthToken})
+
+	err := cmd.Execute()
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "synthetic check")
+	assert.Contains(t, err.Error(), "not found")
+}

--- a/internal/views/integration_test.go
+++ b/internal/views/integration_test.go
@@ -83,3 +83,66 @@ func TestListViews_YAMLFormat(t *testing.T) {
 	// Multiple documents should be separated by ---
 	assert.Contains(t, output, "---")
 }
+
+// TestGetView_NotFound pins the clean-message contract on 404 GET.
+func TestGetView_NotFound(t *testing.T) {
+	testutil.SetupTestEnv(t)
+
+	server := testutil.NewMockServer(t, testutil.FixturesDir())
+	server.OnPattern(http.MethodGet, viewIDPattern, testutil.MockResponse{
+		StatusCode: http.StatusNotFound,
+		BodyFile:   testutil.FixtureViewsNotFound,
+		Validator:  testutil.RequireHeaders,
+	})
+
+	cmd := NewViewsCmd()
+	cmd.SetArgs([]string{"get", "00000000-0000-0000-0000-000000000000", "--api-url", server.URL, "--auth-token", testAuthToken})
+
+	err := cmd.Execute()
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "view")
+	assert.Contains(t, err.Error(), "not found")
+}
+
+// TestGetView_Unauthorized pins the clean-message contract on 401.
+func TestGetView_Unauthorized(t *testing.T) {
+	testutil.SetupTestEnv(t)
+
+	server := testutil.NewMockServer(t, testutil.FixturesDir())
+	server.OnPattern(http.MethodGet, viewIDPattern, testutil.MockResponse{
+		StatusCode: http.StatusUnauthorized,
+		BodyFile:   fixtureUnauthorized,
+		Validator:  testutil.RequireHeaders,
+	})
+
+	cmd := NewViewsCmd()
+	cmd.SetArgs([]string{"get", "00000000-0000-0000-0000-000000000000", "--api-url", server.URL, "--auth-token", "auth_invalid"})
+
+	err := cmd.Execute()
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "authentication failed")
+}
+
+// TestDeleteView_NotFound covers the imperative delete path when the server
+// returns 404.
+func TestDeleteView_NotFound(t *testing.T) {
+	testutil.SetupTestEnv(t)
+
+	server := testutil.NewMockServer(t, testutil.FixturesDir())
+	server.OnPattern(http.MethodDelete, viewIDPattern, testutil.MockResponse{
+		StatusCode: http.StatusNotFound,
+		BodyFile:   testutil.FixtureViewsNotFound,
+		Validator:  testutil.RequireHeaders,
+	})
+
+	cmd := NewViewsCmd()
+	cmd.SetArgs([]string{"delete", "00000000-0000-0000-0000-000000000000", "--force", "--api-url", server.URL, "--auth-token", testAuthToken})
+
+	err := cmd.Execute()
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "view")
+	assert.Contains(t, err.Error(), "not found")
+}

--- a/test/roundtrip/fixtures/dashboard.yaml
+++ b/test/roundtrip/fixtures/dashboard.yaml
@@ -1,3 +1,4 @@
+apiVersion: dash0.com/v1alpha1
 kind: Dashboard
 metadata:
   name: ""

--- a/test/roundtrip/fixtures/notification-channel.yaml
+++ b/test/roundtrip/fixtures/notification-channel.yaml
@@ -1,3 +1,4 @@
+apiVersion: dash0.com/v1alpha1
 kind: Dash0NotificationChannel
 metadata:
   name: CLI Roundtrip Test Channel

--- a/test/roundtrip/fixtures/spam-filter.yaml
+++ b/test/roundtrip/fixtures/spam-filter.yaml
@@ -1,3 +1,4 @@
+apiVersion: v1alpha1
 kind: Dash0SpamFilter
 metadata:
   name: Drop noisy health checks

--- a/test/roundtrip/fixtures/synthetic-check.yaml
+++ b/test/roundtrip/fixtures/synthetic-check.yaml
@@ -1,3 +1,4 @@
+apiVersion: dash0.com/v1alpha1
 kind: Dash0SyntheticCheck
 metadata:
   name: new-synthetic-check

--- a/test/roundtrip/fixtures/team.yaml
+++ b/test/roundtrip/fixtures/team.yaml
@@ -1,3 +1,4 @@
+apiVersion: dash0.com/v1alpha1
 kind: Dash0Team
 metadata:
   name: roundtrip-team

--- a/test/roundtrip/fixtures/view.yaml
+++ b/test/roundtrip/fixtures/view.yaml
@@ -1,3 +1,4 @@
+apiVersion: dash0.com/v1alpha1
 kind: Dash0View
 metadata:
   name: minecraft-server


### PR DESCRIPTION
Pin an explicit apiVersion on every user-authored YAML example in docs/commands.md (Dashboard, CheckRule, View, SyntheticCheck, Dash0NotificationChannel, Dash0Team, and the multi-document example), mirror the change into the roundtrip fixtures, and regenerate the dash0-cli Agent Skill bundle so make skill-validate stays green.