### PR TITLE
fix(delete): treat 404 with --force as idempotent success

### DIFF
--- a/.agents/skills/dash0-cli/SKILL.md
+++ b/.agents/skills/dash0-cli/SKILL.md
@@ -133,7 +133,7 @@ dash0 logs query --from now-1h --filter "otel.log.severity.range is_one_of ERROR
 ### Non-interactive deletion (for automation)
 
 Always pass `--force` to skip the confirmation prompt: `dash0 dashboards delete <id> --force`.
-With `--force`, an already-deleted asset is treated as idempotent success — the command exits 0 and prints a short "already deleted" line to stderr. Without `--force`, a missing asset still surfaces as a non-zero exit with a "not found" error. This is uniform across every `delete` subcommand.
+With `--force`, an already-deleted asset is treated as idempotent success — the command exits 0 and prints a short "already deleted" line to stderr. Without `--force`, a missing asset still surfaces as a non-zero exit with a "not found" error. This is uniform across every `delete` subcommand and every `remove`-shaped variant (`members remove`, `teams remove-members`); in the multi-target variants the check runs per member so one concurrently-removed member does not fail the whole call.
 
 ### Validate assets before applying
 

--- a/.agents/skills/dash0-cli/SKILL.md
+++ b/.agents/skills/dash0-cli/SKILL.md
@@ -133,6 +133,7 @@ dash0 logs query --from now-1h --filter "otel.log.severity.range is_one_of ERROR
 ### Non-interactive deletion (for automation)
 
 Always pass `--force` to skip the confirmation prompt: `dash0 dashboards delete <id> --force`.
+With `--force`, an already-deleted asset is treated as idempotent success — the command exits 0 and prints a short "already deleted" line to stderr. Without `--force`, a missing asset still surfaces as a non-zero exit with a "not found" error. This is uniform across every `delete` subcommand.
 
 ### Validate assets before applying
 

--- a/.chloggen/fix_217.yaml
+++ b/.chloggen/fix_217.yaml
@@ -1,0 +1,33 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern (e.g. dashboards, config, apply)
+component: delete
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "`delete --force` now treats an already-deleted asset as idempotent success"
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [217]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  Every `delete` subcommand (dashboards, check-rules, synthetic-checks, views,
+  recording-rules, notification-channels, spam-filters, teams) now exits 0 and
+  prints a short "already deleted" line to stderr when the target asset is
+  already gone and `--force` was set. Without `--force`, a missing asset still
+  surfaces as a non-zero exit with a clean "not found" error. This makes
+  `delete --force` safe to invoke from CI/CD and agent-driven pipelines where
+  the asset may have been removed concurrently by another actor.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with "chore" or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Default: '[user]'
+change_logs: []

--- a/.chloggen/fix_217.yaml
+++ b/.chloggen/fix_217.yaml
@@ -17,12 +17,15 @@ issues: [217]
 # Use pipe (|) for multiline entries.
 subtext: |
   Every `delete` subcommand (dashboards, check-rules, synthetic-checks, views,
-  recording-rules, notification-channels, spam-filters, teams) now exits 0 and
-  prints a short "already deleted" line to stderr when the target asset is
-  already gone and `--force` was set. Without `--force`, a missing asset still
-  surfaces as a non-zero exit with a clean "not found" error. This makes
+  recording-rules, notification-channels, spam-filters, teams) and every
+  `remove`-shaped variant (`members remove`, `teams remove-members`) now
+  exits 0 and prints a short "already deleted" line to stderr when the target
+  is already gone and `--force` was set. The `remove` variants apply the
+  check per member so one concurrently-removed member does not fail the
+  whole `--force` call. Without `--force`, a missing target still surfaces
+  as a non-zero exit with a clean "not found" error. This makes
   `delete --force` safe to invoke from CI/CD and agent-driven pipelines where
-  the asset may have been removed concurrently by another actor.
+  the target may have been removed concurrently by another actor.
 
 # If your change doesn't affect end users or the exported elements of any package,
 # you should instead start your pull request title with "chore" or use the "Skip Changelog" label.

--- a/.claude/skills/dash0-cli/SKILL.md
+++ b/.claude/skills/dash0-cli/SKILL.md
@@ -133,7 +133,7 @@ dash0 logs query --from now-1h --filter "otel.log.severity.range is_one_of ERROR
 ### Non-interactive deletion (for automation)
 
 Always pass `--force` to skip the confirmation prompt: `dash0 dashboards delete <id> --force`.
-With `--force`, an already-deleted asset is treated as idempotent success — the command exits 0 and prints a short "already deleted" line to stderr. Without `--force`, a missing asset still surfaces as a non-zero exit with a "not found" error. This is uniform across every `delete` subcommand.
+With `--force`, an already-deleted asset is treated as idempotent success — the command exits 0 and prints a short "already deleted" line to stderr. Without `--force`, a missing asset still surfaces as a non-zero exit with a "not found" error. This is uniform across every `delete` subcommand and every `remove`-shaped variant (`members remove`, `teams remove-members`); in the multi-target variants the check runs per member so one concurrently-removed member does not fail the whole call.
 
 ### Validate assets before applying
 

--- a/.claude/skills/dash0-cli/SKILL.md
+++ b/.claude/skills/dash0-cli/SKILL.md
@@ -133,6 +133,7 @@ dash0 logs query --from now-1h --filter "otel.log.severity.range is_one_of ERROR
 ### Non-interactive deletion (for automation)
 
 Always pass `--force` to skip the confirmation prompt: `dash0 dashboards delete <id> --force`.
+With `--force`, an already-deleted asset is treated as idempotent success — the command exits 0 and prints a short "already deleted" line to stderr. Without `--force`, a missing asset still surfaces as a non-zero exit with a "not found" error. This is uniform across every `delete` subcommand.
 
 ### Validate assets before applying
 

--- a/docs/adding-commands.md
+++ b/docs/adding-commands.md
@@ -88,6 +88,10 @@ See @docs/code-style.md [agent mode](code-style.md#agent-mode) for why.
 
 For destructive commands, add `--force` and use `confirmation.ConfirmDestructiveOperation`.
 
+For `delete` subcommands (and `remove`-shaped variants like `members remove` and `teams remove-members`), call `client.IsAlreadyDeleted(err, flags.Force, ectx)` before falling through to `client.HandleAPIError`.
+When it returns `true`, return `nil` — the desired end-state already holds and the helper has already printed an "already deleted" line to stderr.
+See the [Idempotent `delete --force`](cli-naming-conventions.md#idempotent-delete---force) rule in @docs/cli-naming-conventions.md; it is enforced in review.
+
 ## 6. Implement the command logic
 
 - Use `RunE` (not `Run`) and return errors.

--- a/docs/cli-naming-conventions.md
+++ b/docs/cli-naming-conventions.md
@@ -20,6 +20,15 @@ All asset commands (`dashboards`, `check-rules`, `views`, `synthetic-checks`, `r
 | `update`   | -        | Update an existing asset from a file |
 | `delete`   | `remove` | Delete an asset by ID                |
 
+### Idempotent `delete --force`
+Every `delete` subcommand — including `remove`-shaped variants like `members remove` and `teams remove-members` — must treat a 404 from the server as success when the caller passed `--force`.
+The desired end-state ("asset is gone") already holds regardless of who removed it, so returning a non-zero exit code punishes CI/CD and agent-driven pipelines for concurrency they cannot always avoid.
+Without `--force`, a 404 must surface as a clean "asset not found" error (via `client.HandleAPIError` with an `ErrorContext`), not a raw HTTP dump.
+
+The shared helper is `client.IsAlreadyDeleted(err, force, ectx)` in `internal/client/client.go`.
+Every delete path must call it before falling through to `client.HandleAPIError`; the helper prints an "already deleted" line to stderr and returns `true` when force is set and the error is a 404.
+This is a hard rule, not a guideline — adding a new delete command without this wiring is incomplete work and will be flagged in review.
+
 ## Config Profiles Subcommands
 The `config profiles` command uses:
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -687,7 +687,9 @@ $ echo $?
 ```
 
 Without `--force`, a missing asset surfaces as a non-zero exit with a "not found" error.
-The idempotent behavior applies uniformly to every `delete` subcommand (`dashboards`, `check-rules`, `synthetic-checks`, `views`, `recording-rules`, `notification-channels`, `spam-filters`, `teams`) — see also the [Non-interactive deletion (for automation)](#non-interactive-deletion-for-automation) workflow.
+The idempotent behavior applies uniformly to every `delete` subcommand (`dashboards`, `check-rules`, `synthetic-checks`, `views`, `recording-rules`, `notification-channels`, `spam-filters`, `teams`) as well as the `remove`-shaped variants (`members remove`, `teams remove-members`).
+In the multi-target `remove` variants the check runs per member, so one concurrently-removed member does not fail the whole `--force` call — the loop keeps going.
+See also the [Non-interactive deletion (for automation)](#non-interactive-deletion-for-automation) workflow.
 
 Aliases: `remove`
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -676,6 +676,19 @@ $ dash0 dashboards delete a1b2c3d4-5678-90ab-cdef-1234567890ab --force
 Dashboard "a1b2c3d4-..." deleted
 ```
 
+With `--force`, an already-deleted asset is treated as success (exit 0) — a short "already deleted" line is printed to stderr and the command returns without error.
+This makes `delete --force` safe to run from CI/CD and agent-driven pipelines where the asset may have been removed concurrently by another actor:
+
+```bash
+$ dash0 dashboards delete a1b2c3d4-5678-90ab-cdef-1234567890ab --force
+Dashboard "a1b2c3d4-5678-90ab-cdef-1234567890ab" was already deleted
+$ echo $?
+0
+```
+
+Without `--force`, a missing asset surfaces as a non-zero exit with a "not found" error.
+The idempotent behavior applies uniformly to every `delete` subcommand (`dashboards`, `check-rules`, `synthetic-checks`, `views`, `recording-rules`, `notification-channels`, `spam-filters`, `teams`) — see also the [Non-interactive deletion (for automation)](#non-interactive-deletion-for-automation) workflow.
+
 Aliases: `remove`
 
 ### Asset type quick reference
@@ -2720,6 +2733,9 @@ Always pass `--force` to skip the confirmation prompt:
 ```bash
 dash0 dashboards delete a1b2c3d4-... --force
 ```
+
+With `--force`, an asset that is already gone is treated as success: the command exits 0 and prints an "already deleted" line to stderr.
+This is safe to invoke from GitOps or agent-driven pipelines even when another actor may have deleted the asset concurrently.
 
 ### Validate assets before applying
 

--- a/internal/checkrules/delete.go
+++ b/internal/checkrules/delete.go
@@ -55,10 +55,11 @@ func runDelete(ctx context.Context, id string, flags *asset.DeleteFlags) error {
 
 	err = apiClient.DeleteCheckRule(ctx, id, client.ResolveDataset(ctx, flags.Dataset))
 	if err != nil {
-		return client.HandleAPIError(err, client.ErrorContext{
-			AssetType: "check rule",
-			AssetID:   id,
-		})
+		ectx := client.ErrorContext{AssetType: "check rule", AssetID: id}
+		if client.IsAlreadyDeleted(err, flags.Force, ectx) {
+			return nil
+		}
+		return client.HandleAPIError(err, ectx)
 	}
 
 	fmt.Printf("Check rule %q deleted\n", id)

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"unicode"
 
 	dash0api "github.com/dash0hq/dash0-api-client-go"
 	"github.com/dash0hq/dash0-api-client-go/profiles"
@@ -432,5 +433,40 @@ func formatAPIError(prefix string, err error) error {
 		return fmt.Errorf("%s", statusLine)
 	}
 	return fmt.Errorf("%s:\n  %s", statusLine, detail)
+}
+
+// IsAlreadyDeleted implements idempotent `delete --force` semantics: when the
+// delete API call returned 404 and force was set, the desired end-state
+// ("asset is gone") already holds, so callers should treat the response as
+// success. As a side effect, a short "was already deleted" line is written to
+// stderr so the operator (or agent) sees that nothing was actually removed.
+// Returns false when the caller should fall through to the normal error path.
+func IsAlreadyDeleted(err error, force bool, ectx ErrorContext) bool {
+	if err == nil || !force || !dash0api.IsNotFound(err) {
+		return false
+	}
+	identifier := ectx.AssetName
+	if identifier == "" {
+		identifier = ectx.AssetID
+	}
+	assetType := capitalizeFirst(ectx.AssetType)
+	if assetType == "" {
+		assetType = "Asset"
+	}
+	if identifier != "" {
+		fmt.Fprintf(os.Stderr, "%s %q was already deleted\n", assetType, identifier)
+	} else {
+		fmt.Fprintf(os.Stderr, "%s was already deleted\n", assetType)
+	}
+	return true
+}
+
+func capitalizeFirst(s string) string {
+	if s == "" {
+		return s
+	}
+	runes := []rune(s)
+	runes[0] = unicode.ToUpper(runes[0])
+	return string(runes)
 }
 

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -1,8 +1,10 @@
 package client
 
 import (
+	"bytes"
 	"context"
 	"fmt"
+	"io"
 	"os"
 	"strings"
 	"testing"
@@ -427,6 +429,104 @@ func TestCheckOAuthOnOtlp_FlagOverrideShadowsOAuth(t *testing.T) {
 	if err := checkOAuthOnOtlp(context.Background(), cfg, "auth_flag_override_xxx"); err != nil {
 		t.Errorf("expected --auth-token override to suppress the gate, got %v", err)
 	}
+}
+
+func captureStderr(t *testing.T, fn func()) string {
+	t.Helper()
+	oldStderr := os.Stderr
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("failed to create pipe: %v", err)
+	}
+	os.Stderr = w
+	fn()
+	w.Close()
+	os.Stderr = oldStderr
+
+	var buf bytes.Buffer
+	_, _ = io.Copy(&buf, r)
+	r.Close()
+	return buf.String()
+}
+
+// TestIsAlreadyDeleted_ForceAnd404 asserts that when force is true and the
+// delete call returned 404, the helper prints a stderr notice and reports
+// the delete as "already handled" so the caller can return nil (exit 0).
+func TestIsAlreadyDeleted_ForceAnd404(t *testing.T) {
+	notFound := &dash0api.APIError{StatusCode: 404, Status: "404 Not Found"}
+
+	var handled bool
+	stderr := captureStderr(t, func() {
+		handled = IsAlreadyDeleted(notFound, true, ErrorContext{
+			AssetType: "team",
+			AssetID:   "team_01FAKE",
+		})
+	})
+
+	assert.True(t, handled, "expected force+404 to be treated as already-deleted")
+	assert.Contains(t, stderr, `Team "team_01FAKE" was already deleted`)
+}
+
+// TestIsAlreadyDeleted_WithoutForceReturnsFalse asserts that a 404 without
+// --force falls through to the normal error path so the CLI still exits
+// non-zero for interactive users who did not opt into idempotent deletes.
+func TestIsAlreadyDeleted_WithoutForceReturnsFalse(t *testing.T) {
+	notFound := &dash0api.APIError{StatusCode: 404}
+
+	var handled bool
+	stderr := captureStderr(t, func() {
+		handled = IsAlreadyDeleted(notFound, false, ErrorContext{
+			AssetType: "dashboard",
+			AssetID:   "abc",
+		})
+	})
+
+	assert.False(t, handled)
+	assert.Empty(t, stderr, "no stderr notice expected without --force")
+}
+
+// TestIsAlreadyDeleted_NonNotFoundReturnsFalse asserts that other API errors
+// (e.g. 500) are not swallowed by the idempotent-delete path even with
+// --force.
+func TestIsAlreadyDeleted_NonNotFoundReturnsFalse(t *testing.T) {
+	serverErr := &dash0api.APIError{StatusCode: 500}
+
+	var handled bool
+	stderr := captureStderr(t, func() {
+		handled = IsAlreadyDeleted(serverErr, true, ErrorContext{
+			AssetType: "dashboard",
+			AssetID:   "abc",
+		})
+	})
+
+	assert.False(t, handled)
+	assert.Empty(t, stderr)
+}
+
+// TestIsAlreadyDeleted_NilErrReturnsFalse asserts the helper is a no-op on
+// successful (nil) responses so the caller still prints its normal success
+// message.
+func TestIsAlreadyDeleted_NilErrReturnsFalse(t *testing.T) {
+	handled := IsAlreadyDeleted(nil, true, ErrorContext{AssetType: "team", AssetID: "abc"})
+	assert.False(t, handled)
+}
+
+// TestIsAlreadyDeleted_UsesAssetNameWhenAvailable asserts that the stderr
+// notice prefers the human-readable AssetName over the raw AssetID when
+// both are set — mirrors HandleAPIError's identifier resolution.
+func TestIsAlreadyDeleted_UsesAssetNameWhenAvailable(t *testing.T) {
+	notFound := &dash0api.APIError{StatusCode: 404}
+
+	stderr := captureStderr(t, func() {
+		IsAlreadyDeleted(notFound, true, ErrorContext{
+			AssetType: "dashboard",
+			AssetID:   "abc-123",
+			AssetName: "Production Overview",
+		})
+	})
+
+	assert.Contains(t, stderr, `Dashboard "Production Overview" was already deleted`)
+	assert.NotContains(t, stderr, "abc-123")
 }
 
 // TestCheckOAuthOnOtlp_AgentModeMessage asserts the agent-mode branch

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -1,10 +1,8 @@
 package client
 
 import (
-	"bytes"
 	"context"
 	"fmt"
-	"io"
 	"os"
 	"strings"
 	"testing"
@@ -12,6 +10,7 @@ import (
 	dash0api "github.com/dash0hq/dash0-api-client-go"
 	"github.com/dash0hq/dash0-api-client-go/profiles"
 	"github.com/dash0hq/dash0-cli/internal/agentmode"
+	"github.com/dash0hq/dash0-cli/internal/testutil"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -431,24 +430,6 @@ func TestCheckOAuthOnOtlp_FlagOverrideShadowsOAuth(t *testing.T) {
 	}
 }
 
-func captureStderr(t *testing.T, fn func()) string {
-	t.Helper()
-	oldStderr := os.Stderr
-	r, w, err := os.Pipe()
-	if err != nil {
-		t.Fatalf("failed to create pipe: %v", err)
-	}
-	os.Stderr = w
-	fn()
-	w.Close()
-	os.Stderr = oldStderr
-
-	var buf bytes.Buffer
-	_, _ = io.Copy(&buf, r)
-	r.Close()
-	return buf.String()
-}
-
 // TestIsAlreadyDeleted_ForceAnd404 asserts that when force is true and the
 // delete call returned 404, the helper prints a stderr notice and reports
 // the delete as "already handled" so the caller can return nil (exit 0).
@@ -456,7 +437,7 @@ func TestIsAlreadyDeleted_ForceAnd404(t *testing.T) {
 	notFound := &dash0api.APIError{StatusCode: 404, Status: "404 Not Found"}
 
 	var handled bool
-	stderr := captureStderr(t, func() {
+	stderr := testutil.CaptureStderr(t, func() {
 		handled = IsAlreadyDeleted(notFound, true, ErrorContext{
 			AssetType: "team",
 			AssetID:   "team_01FAKE",
@@ -474,7 +455,7 @@ func TestIsAlreadyDeleted_WithoutForceReturnsFalse(t *testing.T) {
 	notFound := &dash0api.APIError{StatusCode: 404}
 
 	var handled bool
-	stderr := captureStderr(t, func() {
+	stderr := testutil.CaptureStderr(t, func() {
 		handled = IsAlreadyDeleted(notFound, false, ErrorContext{
 			AssetType: "dashboard",
 			AssetID:   "abc",
@@ -492,7 +473,7 @@ func TestIsAlreadyDeleted_NonNotFoundReturnsFalse(t *testing.T) {
 	serverErr := &dash0api.APIError{StatusCode: 500}
 
 	var handled bool
-	stderr := captureStderr(t, func() {
+	stderr := testutil.CaptureStderr(t, func() {
 		handled = IsAlreadyDeleted(serverErr, true, ErrorContext{
 			AssetType: "dashboard",
 			AssetID:   "abc",
@@ -517,7 +498,7 @@ func TestIsAlreadyDeleted_NilErrReturnsFalse(t *testing.T) {
 func TestIsAlreadyDeleted_UsesAssetNameWhenAvailable(t *testing.T) {
 	notFound := &dash0api.APIError{StatusCode: 404}
 
-	stderr := captureStderr(t, func() {
+	stderr := testutil.CaptureStderr(t, func() {
 		IsAlreadyDeleted(notFound, true, ErrorContext{
 			AssetType: "dashboard",
 			AssetID:   "abc-123",

--- a/internal/dashboards/delete.go
+++ b/internal/dashboards/delete.go
@@ -55,10 +55,11 @@ func runDelete(ctx context.Context, id string, flags *asset.DeleteFlags) error {
 
 	err = apiClient.DeleteDashboard(ctx, id, client.ResolveDataset(ctx, flags.Dataset))
 	if err != nil {
-		return client.HandleAPIError(err, client.ErrorContext{
-			AssetType: "dashboard",
-			AssetID:   id,
-		})
+		ectx := client.ErrorContext{AssetType: "dashboard", AssetID: id}
+		if client.IsAlreadyDeleted(err, flags.Force, ectx) {
+			return nil
+		}
+		return client.HandleAPIError(err, ectx)
 	}
 
 	fmt.Printf("Dashboard %q deleted\n", id)

--- a/internal/dashboards/integration_test.go
+++ b/internal/dashboards/integration_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/dash0hq/dash0-cli/internal/confirmation"
 	"github.com/dash0hq/dash0-cli/internal/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -376,4 +377,81 @@ func TestListDashboards_RequestRecording(t *testing.T) {
 	assert.Equal(t, apiPathDashboards, req.Path)
 	assert.Contains(t, req.Query, "dataset=my-dataset")
 	assert.True(t, strings.HasPrefix(req.Header.Get("Authorization"), "Bearer "))
+}
+
+// TestDeleteDashboard_Success covers the happy path with --force set.
+func TestDeleteDashboard_Success(t *testing.T) {
+	testutil.SetupTestEnv(t)
+
+	server := testutil.NewMockServer(t, testutil.FixturesDir())
+	server.OnPattern(http.MethodDelete, dashboardIDPattern, testutil.MockResponse{
+		StatusCode: http.StatusOK,
+		Body:       map[string]any{},
+		Validator:  testutil.RequireHeaders,
+	})
+
+	cmd := NewDashboardsCmd()
+	cmd.SetArgs([]string{"delete", testDashboardID, "--force", "--api-url", server.URL, "--auth-token", testAuthToken})
+
+	var err error
+	output := testutil.CaptureStdout(t, func() {
+		err = cmd.Execute()
+	})
+
+	require.NoError(t, err)
+	assert.Contains(t, output, "deleted")
+}
+
+// TestDeleteDashboard_ForceIdempotentOn404 asserts that `delete --force`
+// treats an already-deleted asset as success (exit 0) and prints an
+// "already deleted" line to stderr. Regression coverage for issue #217.
+func TestDeleteDashboard_ForceIdempotentOn404(t *testing.T) {
+	testutil.SetupTestEnv(t)
+
+	server := testutil.NewMockServer(t, testutil.FixturesDir())
+	server.OnPattern(http.MethodDelete, dashboardIDPattern, testutil.MockResponse{
+		StatusCode: http.StatusNotFound,
+		BodyFile:   fixtureNotFound,
+		Validator:  testutil.RequireHeaders,
+	})
+
+	cmd := NewDashboardsCmd()
+	cmd.SetArgs([]string{"delete", testDashboardID, "--force", "--api-url", server.URL, "--auth-token", testAuthToken})
+
+	var err error
+	stderr := testutil.CaptureStderr(t, func() {
+		err = cmd.Execute()
+	})
+
+	require.NoError(t, err, "expected exit 0 with --force on 404")
+	assert.Contains(t, stderr, "was already deleted")
+	assert.Contains(t, stderr, testDashboardID)
+}
+
+// TestDeleteDashboard_WithoutForceReturnsNotFound asserts that without
+// --force, a 404 still surfaces as a non-zero exit with a clean
+// "not found" message. Interactively the user would confirm and then hit
+// the API; the test feeds "y\n" via SetReaderForTest to reach the same
+// error path deterministically.
+func TestDeleteDashboard_WithoutForceReturnsNotFound(t *testing.T) {
+	testutil.SetupTestEnv(t)
+
+	server := testutil.NewMockServer(t, testutil.FixturesDir())
+	server.OnPattern(http.MethodDelete, dashboardIDPattern, testutil.MockResponse{
+		StatusCode: http.StatusNotFound,
+		BodyFile:   fixtureNotFound,
+		Validator:  testutil.RequireHeaders,
+	})
+
+	restore := confirmation.SetReaderForTest(strings.NewReader("y\n"))
+	defer restore()
+
+	cmd := NewDashboardsCmd()
+	cmd.SetArgs([]string{"delete", testDashboardID, "--api-url", server.URL, "--auth-token", testAuthToken})
+
+	err := cmd.Execute()
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not found")
+	assert.Contains(t, err.Error(), "dashboard")
 }

--- a/internal/members/integration_test.go
+++ b/internal/members/integration_test.go
@@ -289,3 +289,79 @@ func TestRemoveMember_WithEmailNotFound(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), `no member found with email "unknown@example.com"`)
 }
+
+// TestRemoveMember_ForceIdempotentOn404 asserts that when the API returns
+// 404 for a resolvable member, `remove --force` treats it as idempotent
+// success — the member is already gone. Companion coverage to the
+// dashboards/teams delete tests; issue #217 promises the same behavior on
+// every `delete` and `remove`-shaped path.
+func TestRemoveMember_ForceIdempotentOn404(t *testing.T) {
+	testutil.SetupTestEnv(t)
+
+	server := testutil.NewMockServer(t, testutil.FixturesDir())
+	server.On(http.MethodGet, apiPathMembers, testutil.MockResponse{
+		StatusCode: http.StatusOK,
+		BodyFile:   testutil.FixtureMembersListSuccess,
+		Validator:  testutil.RequireHeaders,
+	})
+	server.OnPattern(http.MethodDelete, regexp.MustCompile(`^/api/members/[^/]+$`), testutil.MockResponse{
+		StatusCode: http.StatusNotFound,
+		Body:       map[string]any{"error": map[string]any{"code": 404, "message": "not found"}},
+		Validator:  testutil.RequireHeaders,
+	})
+
+	cmd := newExperimentalMembersCmd()
+	cmd.SetArgs([]string{"-X", "members", "remove", "user_member1", "--force", "--api-url", server.URL, "--auth-token", testAuthToken})
+
+	var err error
+	stderr := testutil.CaptureStderr(t, func() {
+		err = cmd.Execute()
+	})
+
+	require.NoError(t, err, "expected exit 0 with --force on 404")
+	assert.Contains(t, stderr, "was already deleted")
+	assert.Contains(t, stderr, "user_member1")
+}
+
+// TestRemoveMember_ForceContinuesOn404Across asserts that a 404 on one
+// member does not abort the whole `--force` call — the loop keeps going
+// and the remaining members are still processed.
+func TestRemoveMember_ForceContinuesOn404Across(t *testing.T) {
+	testutil.SetupTestEnv(t)
+
+	server := testutil.NewMockServer(t, testutil.FixturesDir())
+	server.On(http.MethodGet, apiPathMembers, testutil.MockResponse{
+		StatusCode: http.StatusOK,
+		BodyFile:   testutil.FixtureMembersListSuccess,
+		Validator:  testutil.RequireHeaders,
+	})
+	// user_member1 is already gone (404); user_member2 succeeds.
+	server.On(http.MethodDelete, apiPathMembers+"/user_member1", testutil.MockResponse{
+		StatusCode: http.StatusNotFound,
+		Body:       map[string]any{"error": map[string]any{"code": 404, "message": "not found"}},
+		Validator:  testutil.RequireHeaders,
+	})
+	server.On(http.MethodDelete, apiPathMembers+"/user_member2", testutil.MockResponse{
+		StatusCode: http.StatusOK,
+		Body:       map[string]any{},
+		Validator:  testutil.RequireHeaders,
+	})
+
+	cmd := newExperimentalMembersCmd()
+	cmd.SetArgs([]string{"-X", "members", "remove", "user_member1", "user_member2", "--force", "--api-url", server.URL, "--auth-token", testAuthToken})
+
+	var err error
+	var stdout, stderr string
+	stdout = testutil.CaptureStdout(t, func() {
+		stderr = testutil.CaptureStderr(t, func() {
+			err = cmd.Execute()
+		})
+	})
+
+	require.NoError(t, err, "one 404 must not abort the whole --force call")
+	assert.Contains(t, stderr, "user_member1")
+	assert.Contains(t, stderr, "was already deleted")
+	// user_member2 succeeded — its success line lands on stdout.
+	assert.Contains(t, stdout, "user_member2")
+	assert.Contains(t, stdout, "removed")
+}

--- a/internal/members/remove.go
+++ b/internal/members/remove.go
@@ -84,10 +84,15 @@ func runRemove(cmd *cobra.Command, memberIDs []string, flags *removeFlags) error
 	for _, member := range resolved {
 		err = apiClient.DeleteMember(ctx, member.ID)
 		if err != nil {
-			return client.HandleAPIError(err, client.ErrorContext{
+			ectx := client.ErrorContext{
 				AssetType: "member",
 				AssetID:   member.ID,
-			})
+				AssetName: member.DisplayString(),
+			}
+			if client.IsAlreadyDeleted(err, flags.Force, ectx) {
+				continue
+			}
+			return client.HandleAPIError(err, ectx)
 		}
 		fmt.Printf("Member %s removed\n", member.DisplayString())
 	}

--- a/internal/notificationchannels/delete.go
+++ b/internal/notificationchannels/delete.go
@@ -68,10 +68,11 @@ func runDelete(cmd *cobra.Command, originOrID string, flags *deleteFlags) error 
 
 	err = apiClient.DeleteNotificationChannel(ctx, originOrID)
 	if err != nil {
-		return client.HandleAPIError(err, client.ErrorContext{
-			AssetType: "notification channel",
-			AssetID:   originOrID,
-		})
+		ectx := client.ErrorContext{AssetType: "notification channel", AssetID: originOrID}
+		if client.IsAlreadyDeleted(err, flags.Force, ectx) {
+			return nil
+		}
+		return client.HandleAPIError(err, ectx)
 	}
 
 	fmt.Printf("Notification channel deleted (id: %s).\n", originOrID)

--- a/internal/recordingrules/delete.go
+++ b/internal/recordingrules/delete.go
@@ -55,10 +55,11 @@ func runDelete(ctx context.Context, id string, flags *asset.DeleteFlags) error {
 
 	err = apiClient.DeleteRecordingRule(ctx, id, client.ResolveDataset(ctx, flags.Dataset))
 	if err != nil {
-		return client.HandleAPIError(err, client.ErrorContext{
-			AssetType: "recording rule",
-			AssetID:   id,
-		})
+		ectx := client.ErrorContext{AssetType: "recording rule", AssetID: id}
+		if client.IsAlreadyDeleted(err, flags.Force, ectx) {
+			return nil
+		}
+		return client.HandleAPIError(err, ectx)
 	}
 
 	fmt.Printf("Recording rule %q deleted\n", id)

--- a/internal/skill/content/SKILL.md
+++ b/internal/skill/content/SKILL.md
@@ -133,7 +133,7 @@ dash0 logs query --from now-1h --filter "otel.log.severity.range is_one_of ERROR
 ### Non-interactive deletion (for automation)
 
 Always pass `--force` to skip the confirmation prompt: `dash0 dashboards delete <id> --force`.
-With `--force`, an already-deleted asset is treated as idempotent success — the command exits 0 and prints a short "already deleted" line to stderr. Without `--force`, a missing asset still surfaces as a non-zero exit with a "not found" error. This is uniform across every `delete` subcommand.
+With `--force`, an already-deleted asset is treated as idempotent success — the command exits 0 and prints a short "already deleted" line to stderr. Without `--force`, a missing asset still surfaces as a non-zero exit with a "not found" error. This is uniform across every `delete` subcommand and every `remove`-shaped variant (`members remove`, `teams remove-members`); in the multi-target variants the check runs per member so one concurrently-removed member does not fail the whole call.
 
 ### Validate assets before applying
 

--- a/internal/skill/content/SKILL.md
+++ b/internal/skill/content/SKILL.md
@@ -133,6 +133,7 @@ dash0 logs query --from now-1h --filter "otel.log.severity.range is_one_of ERROR
 ### Non-interactive deletion (for automation)
 
 Always pass `--force` to skip the confirmation prompt: `dash0 dashboards delete <id> --force`.
+With `--force`, an already-deleted asset is treated as idempotent success — the command exits 0 and prints a short "already deleted" line to stderr. Without `--force`, a missing asset still surfaces as a non-zero exit with a "not found" error. This is uniform across every `delete` subcommand.
 
 ### Validate assets before applying
 

--- a/internal/spamfilters/delete.go
+++ b/internal/spamfilters/delete.go
@@ -64,10 +64,11 @@ func runDelete(ctx context.Context, id string, flags *asset.DeleteFlags) error {
 	dataset := client.ResolveDataset(ctx, flags.Dataset)
 	err = deleteWithVersionConflictRetry(ctx, apiClient, id, dataset)
 	if err != nil {
-		return client.HandleAPIError(err, client.ErrorContext{
-			AssetType: "spam filter",
-			AssetID:   id,
-		})
+		ectx := client.ErrorContext{AssetType: "spam filter", AssetID: id}
+		if client.IsAlreadyDeleted(err, flags.Force, ectx) {
+			return nil
+		}
+		return client.HandleAPIError(err, ectx)
 	}
 
 	fmt.Printf("Spam filter %q deleted\n", id)

--- a/internal/syntheticchecks/delete.go
+++ b/internal/syntheticchecks/delete.go
@@ -55,10 +55,11 @@ func runDelete(ctx context.Context, id string, flags *asset.DeleteFlags) error {
 
 	err = apiClient.DeleteSyntheticCheck(ctx, id, client.ResolveDataset(ctx, flags.Dataset))
 	if err != nil {
-		return client.HandleAPIError(err, client.ErrorContext{
-			AssetType: "synthetic check",
-			AssetID:   id,
-		})
+		ectx := client.ErrorContext{AssetType: "synthetic check", AssetID: id}
+		if client.IsAlreadyDeleted(err, flags.Force, ectx) {
+			return nil
+		}
+		return client.HandleAPIError(err, ectx)
 	}
 
 	fmt.Printf("Synthetic check %q deleted\n", id)

--- a/internal/teams/delete.go
+++ b/internal/teams/delete.go
@@ -68,10 +68,11 @@ func runDelete(cmd *cobra.Command, originOrID string, flags *deleteFlags) error 
 
 	err = apiClient.DeleteTeam(ctx, originOrID)
 	if err != nil {
-		return client.HandleAPIError(err, client.ErrorContext{
-			AssetType: "team",
-			AssetID:   originOrID,
-		})
+		ectx := client.ErrorContext{AssetType: "team", AssetID: originOrID}
+		if client.IsAlreadyDeleted(err, flags.Force, ectx) {
+			return nil
+		}
+		return client.HandleAPIError(err, ectx)
 	}
 
 	fmt.Printf("Team %q deleted\n", originOrID)

--- a/internal/teams/integration_test.go
+++ b/internal/teams/integration_test.go
@@ -283,6 +283,32 @@ func TestDeleteTeam_Success(t *testing.T) {
 	assert.Contains(t, output, "deleted")
 }
 
+// TestDeleteTeam_ForceIdempotentOn404 asserts that `dash0 teams delete
+// <id> --force` treats a missing team as idempotent success. Regression
+// coverage for issue #217; the reported example is a `teams delete`.
+func TestDeleteTeam_ForceIdempotentOn404(t *testing.T) {
+	testutil.SetupTestEnv(t)
+
+	server := testutil.NewMockServer(t, testutil.FixturesDir())
+	server.OnPattern(http.MethodDelete, regexp.MustCompile(`^/api/teams/[^/]+$`), testutil.MockResponse{
+		StatusCode: http.StatusNotFound,
+		BodyFile:   "teams/error_not_found.json",
+		Validator:  testutil.RequireHeaders,
+	})
+
+	cmd := newExperimentalTeamsCmd()
+	cmd.SetArgs([]string{"-X", "teams", "delete", "team_01FAKE", "--force", "--api-url", server.URL, "--auth-token", testAuthToken})
+
+	var err error
+	stderr := testutil.CaptureStderr(t, func() {
+		err = cmd.Execute()
+	})
+
+	require.NoError(t, err, "expected exit 0 with --force on 404")
+	assert.Contains(t, stderr, "was already deleted")
+	assert.Contains(t, stderr, "team_01FAKE")
+}
+
 func TestAddMembers_Success(t *testing.T) {
 	testutil.SetupTestEnv(t)
 

--- a/internal/teams/integration_test.go
+++ b/internal/teams/integration_test.go
@@ -510,3 +510,78 @@ func TestRemoveMembers_WithEmail(t *testing.T) {
 	assert.Contains(t, output, "bob@example.com")
 	assert.Contains(t, output, "removed from team")
 }
+
+// TestRemoveMembers_ForceIdempotentOn404 asserts that when the team-member
+// deletion returns 404, `remove-members --force` treats it as idempotent
+// success — the member is already gone from the team. Companion to the
+// members-remove test; issue #217 promises the same behavior on every
+// `delete` and `remove`-shaped path.
+func TestRemoveMembers_ForceIdempotentOn404(t *testing.T) {
+	testutil.SetupTestEnv(t)
+
+	server := testutil.NewMockServer(t, testutil.FixturesDir())
+	server.On(http.MethodGet, apiPathMembers, testutil.MockResponse{
+		StatusCode: http.StatusOK,
+		BodyFile:   testutil.FixtureMembersListSuccess,
+		Validator:  testutil.RequireHeaders,
+	})
+	server.OnPattern(http.MethodDelete, regexp.MustCompile(`^/api/teams/[^/]+/members/[^/]+$`), testutil.MockResponse{
+		StatusCode: http.StatusNotFound,
+		Body:       map[string]any{"error": map[string]any{"code": 404, "message": "not found"}},
+		Validator:  testutil.RequireHeaders,
+	})
+
+	cmd := newExperimentalTeamsCmd()
+	cmd.SetArgs([]string{"-X", "teams", "remove-members", "team-1", "user_member1", "--force", "--api-url", server.URL, "--auth-token", testAuthToken})
+
+	var err error
+	stderr := testutil.CaptureStderr(t, func() {
+		err = cmd.Execute()
+	})
+
+	require.NoError(t, err, "expected exit 0 with --force on 404")
+	assert.Contains(t, stderr, "was already deleted")
+	assert.Contains(t, stderr, "user_member1")
+}
+
+// TestRemoveMembers_ForceContinuesOn404Across asserts that a 404 on one
+// team-member removal does not abort the whole `--force` call — the loop
+// keeps going and the remaining members are still processed.
+func TestRemoveMembers_ForceContinuesOn404Across(t *testing.T) {
+	testutil.SetupTestEnv(t)
+
+	server := testutil.NewMockServer(t, testutil.FixturesDir())
+	server.On(http.MethodGet, apiPathMembers, testutil.MockResponse{
+		StatusCode: http.StatusOK,
+		BodyFile:   testutil.FixtureMembersListSuccess,
+		Validator:  testutil.RequireHeaders,
+	})
+	server.On(http.MethodDelete, "/api/teams/team-1/members/user_member1", testutil.MockResponse{
+		StatusCode: http.StatusNotFound,
+		Body:       map[string]any{"error": map[string]any{"code": 404, "message": "not found"}},
+		Validator:  testutil.RequireHeaders,
+	})
+	server.On(http.MethodDelete, "/api/teams/team-1/members/user_member2", testutil.MockResponse{
+		StatusCode: http.StatusOK,
+		Body:       map[string]any{},
+		Validator:  testutil.RequireHeaders,
+	})
+
+	cmd := newExperimentalTeamsCmd()
+	cmd.SetArgs([]string{"-X", "teams", "remove-members", "team-1", "user_member1", "user_member2", "--force", "--api-url", server.URL, "--auth-token", testAuthToken})
+
+	var err error
+	var stdout, stderr string
+	stdout = testutil.CaptureStdout(t, func() {
+		stderr = testutil.CaptureStderr(t, func() {
+			err = cmd.Execute()
+		})
+	})
+
+	require.NoError(t, err, "one 404 must not abort the whole --force call")
+	assert.Contains(t, stderr, "user_member1")
+	assert.Contains(t, stderr, "was already deleted")
+	// user_member2 succeeded — its success line lands on stdout.
+	assert.Contains(t, stdout, "user_member2")
+	assert.Contains(t, stdout, "removed from team")
+}

--- a/internal/teams/remove_members.go
+++ b/internal/teams/remove_members.go
@@ -85,10 +85,15 @@ func runRemoveMembers(cmd *cobra.Command, teamID string, memberIDs []string, fla
 	for _, member := range resolved {
 		err = apiClient.RemoveTeamMember(ctx, teamID, member.ID)
 		if err != nil {
-			return client.HandleAPIError(err, client.ErrorContext{
-				AssetType: "team",
-				AssetID:   teamID,
-			})
+			ectx := client.ErrorContext{
+				AssetType: "team member",
+				AssetID:   member.ID,
+				AssetName: member.DisplayString(),
+			}
+			if client.IsAlreadyDeleted(err, flags.Force, ectx) {
+				continue
+			}
+			return client.HandleAPIError(err, ectx)
 		}
 		fmt.Printf("Member %s removed from team %q\n", member.DisplayString(), teamID)
 	}

--- a/internal/views/delete.go
+++ b/internal/views/delete.go
@@ -55,10 +55,11 @@ func runDelete(ctx context.Context, id string, flags *asset.DeleteFlags) error {
 
 	err = apiClient.DeleteView(ctx, id, client.ResolveDataset(ctx, flags.Dataset))
 	if err != nil {
-		return client.HandleAPIError(err, client.ErrorContext{
-			AssetType: "view",
-			AssetID:   id,
-		})
+		ectx := client.ErrorContext{AssetType: "view", AssetID: id}
+		if client.IsAlreadyDeleted(err, flags.Force, ectx) {
+			return nil
+		}
+		return client.HandleAPIError(err, ectx)
 	}
 
 	fmt.Printf("View %q deleted\n", id)


### PR DESCRIPTION
Applies uniformly to every `delete` subcommand (`dashboards`, `check-rules`, `synthetic-checks`, `views`, `recording-rules`, `notification-channels`, `spam-filters`, `teams`) that `delete --force` on an already-gone asset now exits 0 with a short "already deleted" line on stderr, so CI/CD and agent pipelines don't get punished for concurrent deletions.

Without `--force`, a missing asset still surfaces as a non-zero exit with the existing clean "not found" error.

Fixes #217