### PR TITLE
chore(tests): drop --force from delete-404 tests after #217

### DIFF
--- a/internal/checkrules/integration_test.go
+++ b/internal/checkrules/integration_test.go
@@ -5,8 +5,10 @@ package checkrules
 import (
 	"net/http"
 	"regexp"
+	"strings"
 	"testing"
 
+	"github.com/dash0hq/dash0-cli/internal/confirmation"
 	"github.com/dash0hq/dash0-cli/internal/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -128,7 +130,11 @@ func TestGetCheckRule_Unauthorized(t *testing.T) {
 }
 
 // TestDeleteCheckRule_NotFound covers the imperative delete path when
-// the server returns 404.
+// the server returns 404. `--force` is intentionally omitted: with
+// `--force` the CLI treats a 404 as idempotent success (see issue #217),
+// so the error path this test pins only fires when the user confirmed
+// interactively. SetReaderForTest supplies the "y" that would otherwise
+// come from stdin.
 func TestDeleteCheckRule_NotFound(t *testing.T) {
 	testutil.SetupTestEnv(t)
 
@@ -139,8 +145,11 @@ func TestDeleteCheckRule_NotFound(t *testing.T) {
 		Validator:  testutil.RequireHeaders,
 	})
 
+	restore := confirmation.SetReaderForTest(strings.NewReader("y\n"))
+	defer restore()
+
 	cmd := NewCheckRulesCmd()
-	cmd.SetArgs([]string{"delete", "00000000-0000-0000-0000-000000000000", "--force", "--api-url", server.URL, "--auth-token", testAuthToken})
+	cmd.SetArgs([]string{"delete", "00000000-0000-0000-0000-000000000000", "--api-url", server.URL, "--auth-token", testAuthToken})
 
 	err := cmd.Execute()
 

--- a/internal/recordingrules/integration_test.go
+++ b/internal/recordingrules/integration_test.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/dash0hq/dash0-cli/internal/confirmation"
 	"github.com/dash0hq/dash0-cli/internal/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -261,7 +262,11 @@ func TestGetRecordingRule_Unauthorized(t *testing.T) {
 }
 
 // TestDeleteRecordingRule_NotFound covers the imperative delete path when
-// the server returns 404.
+// the server returns 404. `--force` is intentionally omitted: with
+// `--force` the CLI treats a 404 as idempotent success (see issue #217),
+// so the error path this test pins only fires when the user confirmed
+// interactively. SetReaderForTest supplies the "y" that would otherwise
+// come from stdin.
 func TestDeleteRecordingRule_NotFound(t *testing.T) {
 	testutil.SetupTestEnv(t)
 
@@ -272,8 +277,11 @@ func TestDeleteRecordingRule_NotFound(t *testing.T) {
 		Validator:  testutil.RequireHeaders,
 	})
 
+	restore := confirmation.SetReaderForTest(strings.NewReader("y\n"))
+	defer restore()
+
 	cmd := NewRecordingRulesCmd()
-	cmd.SetArgs([]string{"delete", "00000000-0000-0000-0000-000000000000", "--force", "--api-url", server.URL, "--auth-token", testAuthToken})
+	cmd.SetArgs([]string{"delete", "00000000-0000-0000-0000-000000000000", "--api-url", server.URL, "--auth-token", testAuthToken})
 
 	err := cmd.Execute()
 

--- a/internal/syntheticchecks/integration_test.go
+++ b/internal/syntheticchecks/integration_test.go
@@ -5,8 +5,10 @@ package syntheticchecks
 import (
 	"net/http"
 	"regexp"
+	"strings"
 	"testing"
 
+	"github.com/dash0hq/dash0-cli/internal/confirmation"
 	"github.com/dash0hq/dash0-cli/internal/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -127,7 +129,10 @@ func TestGetSyntheticCheck_Unauthorized(t *testing.T) {
 
 // TestDeleteSyntheticCheck_NotFound covers the imperative delete path when
 // the server returns 404; the CLI must still exit non-zero with the same
-// clean message.
+// clean message. `--force` is intentionally omitted: with `--force` the
+// CLI treats a 404 as idempotent success (see issue #217), so the error
+// path this test pins only fires when the user confirmed interactively.
+// SetReaderForTest supplies the "y" that would otherwise come from stdin.
 func TestDeleteSyntheticCheck_NotFound(t *testing.T) {
 	testutil.SetupTestEnv(t)
 
@@ -138,8 +143,11 @@ func TestDeleteSyntheticCheck_NotFound(t *testing.T) {
 		Validator:  testutil.RequireHeaders,
 	})
 
+	restore := confirmation.SetReaderForTest(strings.NewReader("y\n"))
+	defer restore()
+
 	cmd := NewSyntheticChecksCmd()
-	cmd.SetArgs([]string{"delete", "00000000-0000-0000-0000-000000000000", "--force", "--api-url", server.URL, "--auth-token", testAuthToken})
+	cmd.SetArgs([]string{"delete", "00000000-0000-0000-0000-000000000000", "--api-url", server.URL, "--auth-token", testAuthToken})
 
 	err := cmd.Execute()
 

--- a/internal/views/integration_test.go
+++ b/internal/views/integration_test.go
@@ -5,8 +5,10 @@ package views
 import (
 	"net/http"
 	"regexp"
+	"strings"
 	"testing"
 
+	"github.com/dash0hq/dash0-cli/internal/confirmation"
 	"github.com/dash0hq/dash0-cli/internal/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -126,7 +128,10 @@ func TestGetView_Unauthorized(t *testing.T) {
 }
 
 // TestDeleteView_NotFound covers the imperative delete path when the server
-// returns 404.
+// returns 404. `--force` is intentionally omitted: with `--force` the CLI
+// treats a 404 as idempotent success (see issue #217), so the error path
+// this test pins only fires when the user confirmed interactively.
+// SetReaderForTest supplies the "y" that would otherwise come from stdin.
 func TestDeleteView_NotFound(t *testing.T) {
 	testutil.SetupTestEnv(t)
 
@@ -137,8 +142,11 @@ func TestDeleteView_NotFound(t *testing.T) {
 		Validator:  testutil.RequireHeaders,
 	})
 
+	restore := confirmation.SetReaderForTest(strings.NewReader("y\n"))
+	defer restore()
+
 	cmd := NewViewsCmd()
-	cmd.SetArgs([]string{"delete", "00000000-0000-0000-0000-000000000000", "--force", "--api-url", server.URL, "--auth-token", testAuthToken})
+	cmd.SetArgs([]string{"delete", "00000000-0000-0000-0000-000000000000", "--api-url", server.URL, "--auth-token", testAuthToken})
 
 	err := cmd.Execute()
 


### PR DESCRIPTION
- CI on main is currently red: https://github.com/dash0hq/dash0-cli/actions/runs/30092138809
- Root cause: commit 0bd0bd8 added `TestDelete<Kind>_NotFound` tests (check-rules, recording-rules, synthetic-checks, views) that invoke `delete <id> --force` against a 404 and assert an error — the pre-#217 behavior. #217 changed `delete --force` to treat a 404 as idempotent success, so those four tests now fail on the first build with both changes landed.
- Fix: drop `--force` from each of the four tests and use `confirmation.SetReaderForTest("y\n")` to reach the same 404 error path deterministically. Same pattern already used by `TestDeleteDashboard_WithoutForceReturnsNotFound` in the dashboards package.

Test-only change; no user-visible behavior change and no changelog entry.