### PR TITLE
fix(teams): make `create -f` and `apply` idempotent for UI-downloaded YAMLs

### DIFF
--- a/.agents/skills/dash0-cli/references/apply.md
+++ b/.agents/skills/dash0-cli/references/apply.md
@@ -37,7 +37,9 @@ A CRD that contains no alerting and no recording rules fails validation up front
 The `dash0.com/origin` label is the upsert key when present; otherwise the server assigns a fresh ID on each apply.
 
 `Dash0Team` documents are dispatched to the organization-level teams endpoint (also not associated with a dataset).
-The `dash0.com/origin` label is the upsert key when present; otherwise the server creates a new team on every apply.
+Upsert key selection: `dash0.com/origin` wins when present and PUTs unconditionally.
+When only `dash0.com/id` is present the CLI preflights the team with a GET — on hit it PUTs (idempotent update, the path that makes a UI-downloaded YAML reapply cleanly), on 404 it falls back to POST so a YAML from one organization applies to another as a fresh create, and other preflight errors surface instead of silently creating a duplicate.
+A document with neither label creates a new team on every apply.
 `spec.members` accepts either email addresses (recommended for GitOps) or internal member ids; the server resolves emails during reconciliation and rejects unresolvable ones with a single 400 listing every offender.
 Requires `--experimental`.
 

--- a/.agents/skills/dash0-cli/references/teams.md
+++ b/.agents/skills/dash0-cli/references/teams.md
@@ -50,15 +50,40 @@ Members: 2
 
 ### `teams create` (experimental)
 
-Create a new team.
+Create a team. Two modes are supported.
+
+**Declarative** — read a `TeamDefinitionV1Alpha1` YAML/JSON document.
+Origin wins over id when both labels are present, and `dash0.com/origin` upserts via PUT (create-or-replace).
+When only `dash0.com/id` is present the CLI preflights `GET /api/teams/{id}`: on hit it PUTs (idempotent update — this is what makes reapplying a YAML downloaded from the Dash0 platform UI a no-op), on 404 it falls back to POST (cross-org apply spawns a fresh team with a server-assigned id), and any other error surfaces.
+A document with neither label is created via POST and the server assigns id and origin.
+See the [Asset identifiers and idempotent upsert](#asset-identifiers-and-idempotent-upsert) section for the full rationale.
 
 ```bash
-dash0 -X teams create <name> [--color-from <hex>] [--color-to <hex>] [--member <id>]
+dash0 -X teams create -f <file>
+```
+
+**Imperative** — build a minimal team envelope from flags.
+
+```bash
+dash0 -X teams create <name> [--color-from <hex>] [--color-to <hex>] [--member <id-or-email>]
 ```
 
 _For the exact, always-current flag list, run `dash0 --agent-mode teams create --help`._
 
-Example:
+Declarative example — reapply a team YAML downloaded from the Dash0 UI:
+
+```bash
+$ dash0 -X teams create -f team.yaml
+Team "Backend Team" updated (id: team_01k5vpx97efdnrkqan15b41k84)
+```
+
+Declarative from stdin (the `cat | dash0 …` pipeline is a single command):
+
+```bash
+cat team.yaml | dash0 -X teams create -f -
+```
+
+Imperative example:
 
 ```bash
 $ dash0 -X teams create "Backend Team" --color-from "#FF6B6B" --color-to "#4ECDC4"

--- a/.chloggen/teams_idempotent_apply.yaml
+++ b/.chloggen/teams_idempotent_apply.yaml
@@ -1,0 +1,38 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern (e.g. dashboards, config, apply)
+component: teams
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "`teams create -f` and `apply` are now idempotent for team YAMLs downloaded from the Dash0 platform UI"
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [227]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  `ImportTeam` now consults `dash0.com/id` in `metadata.labels` as a fallback
+  upsert key when `dash0.com/origin` is not set — the API accepts either as
+  the `{originOrId}` path segment. UI-downloaded YAMLs carry only id, so
+  before this fix every `create -f` and every `apply` POSTed a new team.
+
+  For the cross-environment case (a YAML downloaded from one org, applied to
+  another), a preflight `GET /api/teams/{id}` gates the routing: on hit the
+  CLI PUTs (idempotent update), on miss it falls back to POST (fresh create,
+  the id in the file becomes advisory). Previously the miss path surfaced as
+  a "Forbidden: The given team does not belong to your organization" 404.
+
+  Origin still wins when both labels are present.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with "chore" or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Default: '[user]'
+change_logs: []

--- a/.claude/skills/dash0-cli/references/apply.md
+++ b/.claude/skills/dash0-cli/references/apply.md
@@ -37,7 +37,9 @@ A CRD that contains no alerting and no recording rules fails validation up front
 The `dash0.com/origin` label is the upsert key when present; otherwise the server assigns a fresh ID on each apply.
 
 `Dash0Team` documents are dispatched to the organization-level teams endpoint (also not associated with a dataset).
-The `dash0.com/origin` label is the upsert key when present; otherwise the server creates a new team on every apply.
+Upsert key selection: `dash0.com/origin` wins when present and PUTs unconditionally.
+When only `dash0.com/id` is present the CLI preflights the team with a GET — on hit it PUTs (idempotent update, the path that makes a UI-downloaded YAML reapply cleanly), on 404 it falls back to POST so a YAML from one organization applies to another as a fresh create, and other preflight errors surface instead of silently creating a duplicate.
+A document with neither label creates a new team on every apply.
 `spec.members` accepts either email addresses (recommended for GitOps) or internal member ids; the server resolves emails during reconciliation and rejects unresolvable ones with a single 400 listing every offender.
 Requires `--experimental`.
 

--- a/.claude/skills/dash0-cli/references/teams.md
+++ b/.claude/skills/dash0-cli/references/teams.md
@@ -50,15 +50,40 @@ Members: 2
 
 ### `teams create` (experimental)
 
-Create a new team.
+Create a team. Two modes are supported.
+
+**Declarative** — read a `TeamDefinitionV1Alpha1` YAML/JSON document.
+Origin wins over id when both labels are present, and `dash0.com/origin` upserts via PUT (create-or-replace).
+When only `dash0.com/id` is present the CLI preflights `GET /api/teams/{id}`: on hit it PUTs (idempotent update — this is what makes reapplying a YAML downloaded from the Dash0 platform UI a no-op), on 404 it falls back to POST (cross-org apply spawns a fresh team with a server-assigned id), and any other error surfaces.
+A document with neither label is created via POST and the server assigns id and origin.
+See the [Asset identifiers and idempotent upsert](#asset-identifiers-and-idempotent-upsert) section for the full rationale.
 
 ```bash
-dash0 -X teams create <name> [--color-from <hex>] [--color-to <hex>] [--member <id>]
+dash0 -X teams create -f <file>
+```
+
+**Imperative** — build a minimal team envelope from flags.
+
+```bash
+dash0 -X teams create <name> [--color-from <hex>] [--color-to <hex>] [--member <id-or-email>]
 ```
 
 _For the exact, always-current flag list, run `dash0 --agent-mode teams create --help`._
 
-Example:
+Declarative example — reapply a team YAML downloaded from the Dash0 UI:
+
+```bash
+$ dash0 -X teams create -f team.yaml
+Team "Backend Team" updated (id: team_01k5vpx97efdnrkqan15b41k84)
+```
+
+Declarative from stdin (the `cat | dash0 …` pipeline is a single command):
+
+```bash
+cat team.yaml | dash0 -X teams create -f -
+```
+
+Imperative example:
 
 ```bash
 $ dash0 -X teams create "Backend Team" --color-from "#FF6B6B" --color-to "#4ECDC4"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,7 +48,8 @@ Detailed guidelines are split into focused documents:
   The CLI strips it before sending assets to the API (`StripXxxServerFields`), because the CLI should not claim ownership when the asset may be managed by another system.
 
 - **ID** is the user-defined external identifier used for upsert (create-or-replace) operations.
-  When an asset has a user-defined ID, `apply` and the individual import functions always use PUT (which has upsert semantics) instead of POST.
+  When an asset has a user-defined ID, `apply` and the individual import functions route to PUT (which has upsert semantics) instead of POST for most asset types.
+  Teams are the exception: PUT-to-unknown-id returns 404, so the CLI preflights `GET /api/teams/{id}` and falls back to POST on 404 (see the teams entry below).
   The ID field varies by asset type:
   - Check rules: top-level `id` field (`PrometheusAlertRule.Id`)
   - Views: `metadata.labels["dash0.com/id"]` (`ViewLabels.Dash0Comid`)
@@ -58,6 +59,7 @@ Detailed guidelines are split into focused documents:
   - PrometheusRule CRD (alerting and recording rules): `metadata.labels["dash0.com/id"]`
   - Spam filters (v1alpha1 and v1alpha2): `metadata.labels["dash0.com/id"]`, but `metadata.labels["dash0.com/origin"]` takes precedence as the upsert key when both are present
   - Notification channels: no user-settable ID field — `metadata.labels["dash0.com/origin"]` is the upsert key
+  - Teams: `metadata.labels["dash0.com/origin"]` is the primary upsert key; `metadata.labels["dash0.com/id"]` is honored as a fallback when origin is absent. The CLI preflights `GET /api/teams/{id}` and PUTs on hit, POSTs on 404 (cross-org apply), or surfaces other errors.
 
   The user-facing documentation of these fields, including the rationale for idempotent upsert, lives in the [Asset identifiers and idempotent upsert](docs/commands.md#asset-identifiers-and-idempotent-upsert) section of `docs/commands.md`.
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -727,7 +727,7 @@ The identifier field location varies by asset kind:
 | `View` | `metadata.labels["dash0.com/id"]` | |
 | `Dash0SpamFilter` (v1alpha1 and v1alpha2) | `metadata.labels["dash0.com/id"]` | `metadata.labels["dash0.com/origin"]` is preferred over the ID when both are present; an ID-only filter is not fully idempotent because the server reassigns the ID on the first PUT |
 | `Dash0NotificationChannel` | `metadata.labels["dash0.com/origin"]` | There is no user-settable ID field for notification channels — the origin label is the upsert key. A document without it creates a new channel on every apply |
-| `Dash0Team` | `metadata.labels["dash0.com/origin"]` | Organization-level. Same origin-based-upsert semantics as notification channels: a document with `dash0.com/origin` upserts by that origin (PUT), a document without it creates a new team on every apply (POST). `spec.members` accepts email addresses or internal member ids interchangeably |
+| `Dash0Team` | `metadata.labels["dash0.com/origin"]` (`metadata.labels["dash0.com/id"]` when origin is absent) | Organization-level. `dash0.com/origin` is preferred and upserts by that origin (PUT). When only `dash0.com/id` is present the CLI preflights `GET /api/teams/{id}`: on hit it PUTs (idempotent update — this is what makes reapplying a YAML downloaded from the Dash0 platform UI a no-op), on 404 it falls back to POST so cross-org apply stays idempotent, and other errors surface. A document with neither label creates a new team on every apply. `spec.members` accepts email addresses or internal member ids interchangeably |
 
 The `dash0.com/id` label is the user-defined external identifier and is distinct from `dash0.com/origin`, which records the system of record (`dash0-cli`, `terraform`, `ui`).
 The CLI strips `dash0.com/origin` from outbound payloads for the asset types where the server treats origin as provenance metadata (dashboards, views, check rules, synthetic checks), so do not use origin as the upsert key for those kinds.
@@ -773,7 +773,9 @@ A CRD that contains no alerting and no recording rules fails validation up front
 The `dash0.com/origin` label is the upsert key when present; otherwise the server assigns a fresh ID on each apply.
 
 `Dash0Team` documents are dispatched to the organization-level teams endpoint (also not associated with a dataset).
-The `dash0.com/origin` label is the upsert key when present; otherwise the server creates a new team on every apply.
+Upsert key selection: `dash0.com/origin` wins when present and PUTs unconditionally.
+When only `dash0.com/id` is present the CLI preflights the team with a GET — on hit it PUTs (idempotent update, the path that makes a UI-downloaded YAML reapply cleanly), on 404 it falls back to POST so a YAML from one organization applies to another as a fresh create, and other preflight errors surface instead of silently creating a duplicate.
+A document with neither label creates a new team on every apply.
 `spec.members` accepts either email addresses (recommended for GitOps) or internal member ids; the server resolves emails during reconciliation and rejects unresolvable ones with a single 400 listing every offender.
 Requires `--experimental`.
 
@@ -2240,19 +2242,45 @@ Members: 2
 
 ### `teams create` (experimental)
 
-Create a new team.
+Create a team. Two modes are supported.
+
+**Declarative** — read a `TeamDefinitionV1Alpha1` YAML/JSON document.
+Origin wins over id when both labels are present, and `dash0.com/origin` upserts via PUT (create-or-replace).
+When only `dash0.com/id` is present the CLI preflights `GET /api/teams/{id}`: on hit it PUTs (idempotent update — this is what makes reapplying a YAML downloaded from the Dash0 platform UI a no-op), on 404 it falls back to POST (cross-org apply spawns a fresh team with a server-assigned id), and any other error surfaces.
+A document with neither label is created via POST and the server assigns id and origin.
+See the [Asset identifiers and idempotent upsert](#asset-identifiers-and-idempotent-upsert) section for the full rationale.
 
 ```bash
-dash0 -X teams create <name> [--color-from <hex>] [--color-to <hex>] [--member <id>]
+dash0 -X teams create -f <file>
+```
+
+**Imperative** — build a minimal team envelope from flags.
+
+```bash
+dash0 -X teams create <name> [--color-from <hex>] [--color-to <hex>] [--member <id-or-email>]
 ```
 
 | Flag | Description |
 |------|-------------|
-| `--color-from` | Gradient start color (e.g. `"#FF0000"`) |
-| `--color-to` | Gradient end color (e.g. `"#00FF00"`) |
-| `--member` | Member ID to add to the team (repeatable) |
+| `-f`, `--file` | Path to a YAML or JSON `TeamDefinitionV1Alpha1` document (use `-` for stdin); mutually exclusive with the imperative flags |
+| `--color-from` | Gradient start color (e.g. `"#FF0000"`); imperative form only |
+| `--color-to` | Gradient end color (e.g. `"#00FF00"`); imperative form only |
+| `--member` | Member (id or email) to add to the team, repeatable; imperative form only. Emails are resolved to member ids server-side |
 
-Example:
+Declarative example — reapply a team YAML downloaded from the Dash0 UI:
+
+```bash
+$ dash0 -X teams create -f team.yaml
+Team "Backend Team" updated (id: team_01k5vpx97efdnrkqan15b41k84)
+```
+
+Declarative from stdin (the `cat | dash0 …` pipeline is a single command):
+
+```bash
+cat team.yaml | dash0 -X teams create -f -
+```
+
+Imperative example:
 
 ```bash
 $ dash0 -X teams create "Backend Team" --color-from "#FF6B6B" --color-to "#4ECDC4"

--- a/internal/asset/team.go
+++ b/internal/asset/team.go
@@ -6,22 +6,54 @@ import (
 	dash0api "github.com/dash0hq/dash0-api-client-go"
 )
 
-// ImportTeam creates or upserts a team via the CRD Teams API. When the input
-// carries a dash0.com/origin label, PUT is used (create-or-replace by origin).
-// Otherwise, POST is used and the server assigns both id and origin.
+// ImportTeam creates or upserts a team via the CRD Teams API.
+//
+// Upsert key selection:
+//
+//   - If the input has a user-defined origin (label `dash0.com/origin`), a
+//     preflight GetTeam runs against that origin. On hit, PUT is used to
+//     update in place. On miss, PUT is still used — the API treats origin
+//     PUT as create-or-replace, so the team materializes at the requested
+//     origin.
+//   - If the input has a user-defined ID (label `dash0.com/id`) but no
+//     origin, a preflight GetTeam gates the choice: on hit, PUT (idempotent
+//     update); on miss, POST (create fresh with a server-assigned id). The
+//     miss path matters for cross-environment apply: a YAML downloaded from
+//     one Dash0 org carries an id that does not exist in a different org's
+//     backend, and PUT-to-unknown-id returns 404. Falling back to POST keeps
+//     `apply` idempotent — the identifier in the file becomes advisory when
+//     it cannot be honored.
+//   - Otherwise, POST is used and the server assigns both id and origin.
+//
+// dash0.com/id is captured before StripTeamServerFields runs because that
+// helper clears the id label along with the server source label.
 //
 // Before returning, spec.members on both the before and after states is
 // translated from internal IDs (what the server echoes) to email addresses,
 // so the apply diff renderer prints legible membership changes.
 func ImportTeam(ctx context.Context, apiClient dash0api.Client, team *dash0api.TeamDefinitionV1Alpha1) (ImportResult, error) {
+	// Capture identifiers before stripping — StripTeamServerFields clears the
+	// dash0.com/id label, so id-based routing must observe the input first.
+	origin := dash0api.GetTeamOrigin(team)
+	id := dash0api.GetTeamID(team)
 	dash0api.StripTeamServerFields(team)
 
 	action := ActionCreated
 	var before *dash0api.TeamDefinitionV1Alpha1
-	origin := dash0api.GetTeamOrigin(team)
-	if origin != "" {
-		existing, err := apiClient.GetTeam(ctx, origin)
-		if err == nil {
+	var upsertKey string
+	switch {
+	case origin != "":
+		upsertKey = origin
+		if existing, err := apiClient.GetTeam(ctx, origin); err == nil {
+			action = ActionUpdated
+			before = existing
+		}
+	case id != "":
+		// Only route to PUT if the id actually exists in the target env.
+		// Cross-environment applies must not 404; on miss we fall through
+		// to POST so the file's id becomes advisory rather than fatal.
+		if existing, err := apiClient.GetTeam(ctx, id); err == nil {
+			upsertKey = id
 			action = ActionUpdated
 			before = existing
 		}
@@ -29,8 +61,8 @@ func ImportTeam(ctx context.Context, apiClient dash0api.Client, team *dash0api.T
 
 	var result *dash0api.TeamDefinitionV1Alpha1
 	var err error
-	if origin != "" {
-		result, err = apiClient.UpsertTeam(ctx, origin, team)
+	if upsertKey != "" {
+		result, err = apiClient.UpsertTeam(ctx, upsertKey, team)
 	} else {
 		result, err = apiClient.CreateTeam(ctx, team)
 	}
@@ -45,7 +77,7 @@ func ImportTeam(ctx context.Context, apiClient dash0api.Client, team *dash0api.T
 	_ = dash0api.ResolveTeamMembersToEmails(ctx, apiClient, before)
 	_ = dash0api.ResolveTeamMembersToEmails(ctx, apiClient, result)
 
-	id := dash0api.GetTeamID(result)
+	resultID := dash0api.GetTeamID(result)
 	name := dash0api.GetTeamDisplayName(result)
 	if name == "" {
 		name = dash0api.GetTeamName(result)
@@ -54,6 +86,6 @@ func ImportTeam(ctx context.Context, apiClient dash0api.Client, team *dash0api.T
 	if before != nil {
 		beforeAny = before
 	}
-	return ImportResult{Name: name, ID: id, Action: action, Before: beforeAny, After: result}, nil
+	return ImportResult{Name: name, ID: resultID, Action: action, Before: beforeAny, After: result}, nil
 }
 

--- a/internal/asset/team.go
+++ b/internal/asset/team.go
@@ -49,13 +49,22 @@ func ImportTeam(ctx context.Context, apiClient dash0api.Client, team *dash0api.T
 			before = existing
 		}
 	case id != "":
-		// Only route to PUT if the id actually exists in the target env.
-		// Cross-environment applies must not 404; on miss we fall through
-		// to POST so the file's id becomes advisory rather than fatal.
-		if existing, err := apiClient.GetTeam(ctx, id); err == nil {
+		// The preflight GET's outcome decides the route, so the kind of
+		// error matters. Only a genuine 404 permits POST fallback (cross-
+		// environment apply — the id belongs to another org). Any other
+		// error (5xx, auth failure, network blip) must surface — silently
+		// POSTing would create a duplicate on the very failure mode this
+		// path exists to prevent.
+		existing, err := apiClient.GetTeam(ctx, id)
+		switch {
+		case err == nil:
 			upsertKey = id
 			action = ActionUpdated
 			before = existing
+		case dash0api.IsNotFound(err):
+			// Fall through to POST.
+		default:
+			return ImportResult{}, err
 		}
 	}
 

--- a/internal/skill/content/references/apply.md
+++ b/internal/skill/content/references/apply.md
@@ -37,7 +37,9 @@ A CRD that contains no alerting and no recording rules fails validation up front
 The `dash0.com/origin` label is the upsert key when present; otherwise the server assigns a fresh ID on each apply.
 
 `Dash0Team` documents are dispatched to the organization-level teams endpoint (also not associated with a dataset).
-The `dash0.com/origin` label is the upsert key when present; otherwise the server creates a new team on every apply.
+Upsert key selection: `dash0.com/origin` wins when present and PUTs unconditionally.
+When only `dash0.com/id` is present the CLI preflights the team with a GET — on hit it PUTs (idempotent update, the path that makes a UI-downloaded YAML reapply cleanly), on 404 it falls back to POST so a YAML from one organization applies to another as a fresh create, and other preflight errors surface instead of silently creating a duplicate.
+A document with neither label creates a new team on every apply.
 `spec.members` accepts either email addresses (recommended for GitOps) or internal member ids; the server resolves emails during reconciliation and rejects unresolvable ones with a single 400 listing every offender.
 Requires `--experimental`.
 

--- a/internal/skill/content/references/teams.md
+++ b/internal/skill/content/references/teams.md
@@ -50,15 +50,40 @@ Members: 2
 
 ### `teams create` (experimental)
 
-Create a new team.
+Create a team. Two modes are supported.
+
+**Declarative** — read a `TeamDefinitionV1Alpha1` YAML/JSON document.
+Origin wins over id when both labels are present, and `dash0.com/origin` upserts via PUT (create-or-replace).
+When only `dash0.com/id` is present the CLI preflights `GET /api/teams/{id}`: on hit it PUTs (idempotent update — this is what makes reapplying a YAML downloaded from the Dash0 platform UI a no-op), on 404 it falls back to POST (cross-org apply spawns a fresh team with a server-assigned id), and any other error surfaces.
+A document with neither label is created via POST and the server assigns id and origin.
+See the [Asset identifiers and idempotent upsert](#asset-identifiers-and-idempotent-upsert) section for the full rationale.
 
 ```bash
-dash0 -X teams create <name> [--color-from <hex>] [--color-to <hex>] [--member <id>]
+dash0 -X teams create -f <file>
+```
+
+**Imperative** — build a minimal team envelope from flags.
+
+```bash
+dash0 -X teams create <name> [--color-from <hex>] [--color-to <hex>] [--member <id-or-email>]
 ```
 
 _For the exact, always-current flag list, run `dash0 --agent-mode teams create --help`._
 
-Example:
+Declarative example — reapply a team YAML downloaded from the Dash0 UI:
+
+```bash
+$ dash0 -X teams create -f team.yaml
+Team "Backend Team" updated (id: team_01k5vpx97efdnrkqan15b41k84)
+```
+
+Declarative from stdin (the `cat | dash0 …` pipeline is a single command):
+
+```bash
+cat team.yaml | dash0 -X teams create -f -
+```
+
+Imperative example:
 
 ```bash
 $ dash0 -X teams create "Backend Team" --color-from "#FF6B6B" --color-to "#4ECDC4"

--- a/internal/teams/create.go
+++ b/internal/teams/create.go
@@ -37,9 +37,10 @@ func newCreateCmd() *cobra.Command {
 Two modes are supported:
 
 - Declarative: -f <file> reads a TeamDefinitionV1Alpha1 YAML/JSON document.
-  If the document carries a dash0.com/origin label, the team is created or
-  replaced via PUT (idempotent). Otherwise it is created via POST and the
-  server assigns id and origin.
+  If the document carries a dash0.com/origin or dash0.com/id label, the team
+  is created or replaced via PUT (idempotent) against that identifier — the
+  API accepts either. Origin wins when both are present. Otherwise the team
+  is created via POST and the server assigns id and origin.
 - Imperative: create <name> [--color-from ...] [--color-to ...] [--member ...]
   posts a minimal envelope built from flags. --member accepts an email or an
   internal member id; the server resolves emails.` + internal.CONFIG_HINT,

--- a/internal/teams/create.go
+++ b/internal/teams/create.go
@@ -37,10 +37,12 @@ func newCreateCmd() *cobra.Command {
 Two modes are supported:
 
 - Declarative: -f <file> reads a TeamDefinitionV1Alpha1 YAML/JSON document.
-  If the document carries a dash0.com/origin or dash0.com/id label, the team
-  is created or replaced via PUT (idempotent) against that identifier — the
-  API accepts either. Origin wins when both are present. Otherwise the team
-  is created via POST and the server assigns id and origin.
+  Origin wins over id when both labels are present, and dash0.com/origin
+  upserts via PUT (create-or-replace). When only dash0.com/id is present
+  the CLI preflights GET /api/teams/{id}: on hit it PUTs (idempotent update),
+  on 404 it falls back to POST (cross-org apply spawns a fresh team with a
+  server-assigned id), and any other error surfaces. A document with
+  neither label is created via POST and the server assigns id and origin.
 - Imperative: create <name> [--color-from ...] [--color-to ...] [--member ...]
   posts a minimal envelope built from flags. --member accepts an email or an
   internal member id; the server resolves emails.` + internal.CONFIG_HINT,

--- a/internal/teams/integration_test.go
+++ b/internal/teams/integration_test.go
@@ -5,6 +5,8 @@ package teams
 import (
 	"encoding/json"
 	"net/http"
+	"os"
+	"path/filepath"
 	"regexp"
 	"strings"
 	"testing"
@@ -259,6 +261,253 @@ func TestCreateTeam_Success(t *testing.T) {
 
 	require.NoError(t, err)
 	assert.Contains(t, output, "Team \"New Team\" created")
+}
+
+// assertPUTPath finds a PUT request in the recorded stream that targets the
+// given path. Tolerates a trailing /api/members lookup (invoked when the
+// GetTeam pre-check populates the "before" state for the apply diff).
+func assertPUTPath(t *testing.T, requests []testutil.RecordedRequest, wantPath, msg string) {
+	t.Helper()
+	for _, req := range requests {
+		if req.Method == http.MethodPut && req.Path == wantPath {
+			return
+		}
+	}
+	seen := make([]string, 0, len(requests))
+	for _, req := range requests {
+		seen = append(seen, req.Method+" "+req.Path)
+	}
+	t.Fatalf("%s\nwant: PUT %s\ngot requests: %v", msg, wantPath, seen)
+}
+
+// assertPOSTPath finds a POST request in the recorded stream that targets
+// the given path. Mirrors assertPUTPath for the fall-through-to-create path.
+func assertPOSTPath(t *testing.T, requests []testutil.RecordedRequest, wantPath, msg string) {
+	t.Helper()
+	for _, req := range requests {
+		if req.Method == http.MethodPost && req.Path == wantPath {
+			return
+		}
+	}
+	seen := make([]string, 0, len(requests))
+	for _, req := range requests {
+		seen = append(seen, req.Method+" "+req.Path)
+	}
+	t.Fatalf("%s\nwant: POST %s\ngot requests: %v", msg, wantPath, seen)
+}
+
+// TestCreateTeamFromFile_UpsertByID asserts that a declarative team YAML
+// carrying only a dash0.com/id label (no origin) routes to PUT
+// /api/teams/{id} rather than POST when the team exists in the target env.
+// Regression coverage for the "download team from platform UI, reapply via
+// CLI" idempotency loop: the UI download carries id but not origin, so
+// upsert must fall back to id.
+func TestCreateTeamFromFile_UpsertByID(t *testing.T) {
+	testutil.SetupTestEnv(t)
+
+	const teamID = "team_01k5vpx97efdnrkqan15b41k84"
+	teamsIDPattern := regexp.MustCompile(`^/api/teams/team_[^/]+$`)
+
+	server := testutil.NewMockServer(t, testutil.FixturesDir())
+	server.OnPattern(http.MethodGet, teamsIDPattern, testutil.MockResponse{
+		StatusCode: http.StatusOK,
+		BodyFile:   testutil.FixtureTeamsGetSuccess,
+		Validator:  testutil.RequireHeaders,
+	})
+	server.OnPattern(http.MethodPut, teamsIDPattern, testutil.MockResponse{
+		StatusCode: http.StatusOK,
+		BodyFile:   testutil.FixtureTeamsCreateSuccess,
+		Validator:  testutil.RequireHeaders,
+	})
+
+	tmpDir := t.TempDir()
+	yamlFile := filepath.Join(tmpDir, "team.yaml")
+	err := os.WriteFile(yamlFile, []byte(`apiVersion: dash0.com/v1alpha1
+kind: Dash0Team
+metadata:
+  name: some-new-team
+  labels:
+    dash0.com/id: `+teamID+`
+    dash0.com/source: ui
+spec:
+  display:
+    color:
+      from: "#fb7185"
+      to: "#be123c"
+    name: Some new team
+  members: []
+`), 0644)
+	require.NoError(t, err)
+
+	cmd := newExperimentalTeamsCmd()
+	cmd.SetArgs([]string{"-X", "teams", "create", "-f", yamlFile, "--api-url", server.URL, "--auth-token", testAuthToken})
+
+	testutil.CaptureStdout(t, func() {
+		err = cmd.Execute()
+	})
+	require.NoError(t, err)
+
+	assertPUTPath(t, server.Requests(), "/api/teams/"+teamID, "expected PUT-by-id, got POST — the id label should route to upsert")
+}
+
+// TestCreateTeamFromFile_UpsertByID_FallsBackToPOSTWhenNotFound asserts that
+// when the id in the input YAML does not exist in the target environment
+// (cross-environment apply — the classic "download from org A, apply to
+// org B" case), the CLI falls back to POST instead of returning a 404 from
+// PUT. Without this, `dash0 apply` is not idempotent across environments
+// and users see a scary "Forbidden" error on what should be a fresh create.
+func TestCreateTeamFromFile_UpsertByID_FallsBackToPOSTWhenNotFound(t *testing.T) {
+	testutil.SetupTestEnv(t)
+
+	const teamID = "team_01k5vpx97efdnrkqan15b41k84"
+	teamsIDPattern := regexp.MustCompile(`^/api/teams/team_[^/]+$`)
+
+	server := testutil.NewMockServer(t, testutil.FixturesDir())
+	// Pre-check GET returns 404 — the id belongs to a different org.
+	server.OnPattern(http.MethodGet, teamsIDPattern, testutil.MockResponse{
+		StatusCode: http.StatusNotFound,
+		BodyFile:   testutil.FixtureTeamsNotFound,
+		Validator:  testutil.RequireHeaders,
+	})
+	// POST fallback returns the freshly-created team.
+	server.On(http.MethodPost, apiPathTeams, testutil.MockResponse{
+		StatusCode: http.StatusOK,
+		BodyFile:   testutil.FixtureTeamsCreateSuccess,
+		Validator:  testutil.RequireHeaders,
+	})
+
+	tmpDir := t.TempDir()
+	yamlFile := filepath.Join(tmpDir, "team.yaml")
+	err := os.WriteFile(yamlFile, []byte(`apiVersion: dash0.com/v1alpha1
+kind: Dash0Team
+metadata:
+  name: some-new-team
+  labels:
+    dash0.com/id: `+teamID+`
+    dash0.com/source: ui
+spec:
+  display:
+    color:
+      from: "#fb7185"
+      to: "#be123c"
+    name: Some new team
+  members: []
+`), 0644)
+	require.NoError(t, err)
+
+	cmd := newExperimentalTeamsCmd()
+	cmd.SetArgs([]string{"-X", "teams", "create", "-f", yamlFile, "--api-url", server.URL, "--auth-token", testAuthToken})
+
+	testutil.CaptureStdout(t, func() {
+		err = cmd.Execute()
+	})
+	require.NoError(t, err, "cross-env apply must not fail — the id from a different org should trigger POST fallback")
+
+	// No PUT should have been attempted.
+	for _, req := range server.Requests() {
+		assert.NotEqual(t, http.MethodPut, req.Method, "PUT to unknown id would 404; expected POST fallback instead")
+	}
+	assertPOSTPath(t, server.Requests(), apiPathTeams, "expected POST fallback after GET 404")
+}
+
+// TestCreateTeamFromFile_UpsertByOrigin asserts that a declarative team YAML
+// carrying a dash0.com/origin label routes to PUT /api/teams/{origin}.
+func TestCreateTeamFromFile_UpsertByOrigin(t *testing.T) {
+	testutil.SetupTestEnv(t)
+
+	const origin = "my-team-origin"
+	teamsOriginPattern := regexp.MustCompile(`^/api/teams/[^/]+$`)
+
+	server := testutil.NewMockServer(t, testutil.FixturesDir())
+	server.OnPattern(http.MethodGet, teamsOriginPattern, testutil.MockResponse{
+		StatusCode: http.StatusOK,
+		BodyFile:   testutil.FixtureTeamsGetSuccess,
+		Validator:  testutil.RequireHeaders,
+	})
+	server.OnPattern(http.MethodPut, teamsOriginPattern, testutil.MockResponse{
+		StatusCode: http.StatusOK,
+		BodyFile:   testutil.FixtureTeamsCreateSuccess,
+		Validator:  testutil.RequireHeaders,
+	})
+
+	tmpDir := t.TempDir()
+	yamlFile := filepath.Join(tmpDir, "team.yaml")
+	err := os.WriteFile(yamlFile, []byte(`apiVersion: dash0.com/v1alpha1
+kind: Dash0Team
+metadata:
+  name: some-new-team
+  labels:
+    dash0.com/origin: `+origin+`
+spec:
+  display:
+    color:
+      from: "#fb7185"
+      to: "#be123c"
+    name: Some new team
+  members: []
+`), 0644)
+	require.NoError(t, err)
+
+	cmd := newExperimentalTeamsCmd()
+	cmd.SetArgs([]string{"-X", "teams", "create", "-f", yamlFile, "--api-url", server.URL, "--auth-token", testAuthToken})
+
+	testutil.CaptureStdout(t, func() {
+		err = cmd.Execute()
+	})
+	require.NoError(t, err)
+
+	assertPUTPath(t, server.Requests(), "/api/teams/"+origin, "expected PUT to /api/teams/{origin}")
+}
+
+// TestCreateTeamFromFile_OriginWinsOverID asserts that when both origin and
+// id labels are present, origin is the upsert key.
+func TestCreateTeamFromFile_OriginWinsOverID(t *testing.T) {
+	testutil.SetupTestEnv(t)
+
+	const origin = "my-team-origin"
+	const teamID = "team_01k5vpx97efdnrkqan15b41k84"
+	teamsIDPattern := regexp.MustCompile(`^/api/teams/[^/]+$`)
+
+	server := testutil.NewMockServer(t, testutil.FixturesDir())
+	server.OnPattern(http.MethodGet, teamsIDPattern, testutil.MockResponse{
+		StatusCode: http.StatusOK,
+		BodyFile:   testutil.FixtureTeamsGetSuccess,
+		Validator:  testutil.RequireHeaders,
+	})
+	server.OnPattern(http.MethodPut, teamsIDPattern, testutil.MockResponse{
+		StatusCode: http.StatusOK,
+		BodyFile:   testutil.FixtureTeamsCreateSuccess,
+		Validator:  testutil.RequireHeaders,
+	})
+
+	tmpDir := t.TempDir()
+	yamlFile := filepath.Join(tmpDir, "team.yaml")
+	err := os.WriteFile(yamlFile, []byte(`apiVersion: dash0.com/v1alpha1
+kind: Dash0Team
+metadata:
+  name: some-new-team
+  labels:
+    dash0.com/origin: `+origin+`
+    dash0.com/id: `+teamID+`
+spec:
+  display:
+    color:
+      from: "#fb7185"
+      to: "#be123c"
+    name: Some new team
+  members: []
+`), 0644)
+	require.NoError(t, err)
+
+	cmd := newExperimentalTeamsCmd()
+	cmd.SetArgs([]string{"-X", "teams", "create", "-f", yamlFile, "--api-url", server.URL, "--auth-token", testAuthToken})
+
+	testutil.CaptureStdout(t, func() {
+		err = cmd.Execute()
+	})
+	require.NoError(t, err)
+
+	assertPUTPath(t, server.Requests(), "/api/teams/"+origin, "origin must win over id when both are present")
 }
 
 func TestDeleteTeam_Success(t *testing.T) {

--- a/internal/teams/integration_test.go
+++ b/internal/teams/integration_test.go
@@ -410,6 +410,59 @@ spec:
 	assertPOSTPath(t, server.Requests(), apiPathTeams, "expected POST fallback after GET 404")
 }
 
+// TestCreateTeamFromFile_UpsertByID_PropagatesPreflightServerError asserts
+// that when the preflight GET returns a non-404 error (500, 401, network),
+// the command surfaces the error instead of silently falling back to POST.
+// Without this check, a transient backend hiccup would spawn a duplicate
+// team every retry — the exact failure mode the id-fallback path exists
+// to prevent.
+func TestCreateTeamFromFile_UpsertByID_PropagatesPreflightServerError(t *testing.T) {
+	testutil.SetupTestEnv(t)
+	// Disable retries so the test exercises the propagation logic alone,
+	// not the transport's 3-retry backoff on 5xx.
+	t.Setenv("DASH0_MAX_RETRIES", "0")
+
+	const teamID = "team_01k5vpx97efdnrkqan15b41k84"
+	teamsIDPattern := regexp.MustCompile(`^/api/teams/team_[^/]+$`)
+
+	server := testutil.NewMockServer(t, testutil.FixturesDir())
+	// Preflight GET returns 500 — not a "team doesn't exist" signal.
+	server.OnPattern(http.MethodGet, teamsIDPattern, testutil.MockResponse{
+		StatusCode: http.StatusInternalServerError,
+		Body:       map[string]any{"error": "backend blew up"},
+		Validator:  testutil.RequireHeaders,
+	})
+
+	tmpDir := t.TempDir()
+	yamlFile := filepath.Join(tmpDir, "team.yaml")
+	err := os.WriteFile(yamlFile, []byte(`apiVersion: dash0.com/v1alpha1
+kind: Dash0Team
+metadata:
+  name: some-new-team
+  labels:
+    dash0.com/id: `+teamID+`
+spec:
+  display:
+    color:
+      from: "#fb7185"
+      to: "#be123c"
+    name: Some new team
+  members: []
+`), 0644)
+	require.NoError(t, err)
+
+	cmd := newExperimentalTeamsCmd()
+	cmd.SetArgs([]string{"-X", "teams", "create", "-f", yamlFile, "--api-url", server.URL, "--auth-token", testAuthToken})
+
+	testutil.CaptureStdout(t, func() {
+		err = cmd.Execute()
+	})
+	require.Error(t, err, "non-404 preflight errors must surface, not fall through to POST")
+
+	require.Len(t, server.Requests(), 1, "preflight GET must fire exactly once with retries disabled; POST fallback must not run")
+	assert.Equal(t, http.MethodGet, server.Requests()[0].Method, "only the preflight GET should hit the mock")
+}
+
 // TestCreateTeamFromFile_UpsertByOrigin asserts that a declarative team YAML
 // carrying a dash0.com/origin label routes to PUT /api/teams/{origin}.
 func TestCreateTeamFromFile_UpsertByOrigin(t *testing.T) {


### PR DESCRIPTION
Closes #227