### PR TITLE
fix(metrics): sort labels in metrics instant verbose output

### DIFF
--- a/.chloggen/claude_sort-view-synthetic-check-permissions.yaml
+++ b/.chloggen/claude_sort-view-synthetic-check-permissions.yaml
@@ -1,0 +1,29 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern (e.g. dashboards, config, apply)
+component: views, synthetic-checks
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "`spec.permissions` on views and synthetic checks is now sorted lexicographically (by role, then team, then user) before being displayed or diffed."
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [231]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  The Dash0 API does not guarantee a stable order for this field, which previously showed up as
+  spurious changes in `views`/`synthetic-checks` `update --dry-run` and `apply` diffs, and as
+  reordered output across repeated `get`/`list -o yaml` calls.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with "chore" or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Default: '[user]'
+change_logs: []

--- a/.chloggen/claude_yaml-key-sorting-determinism-qlg7ns.yaml
+++ b/.chloggen/claude_yaml-key-sorting-determinism-qlg7ns.yaml
@@ -1,0 +1,28 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern (e.g. dashboards, config, apply)
+component: metrics
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "`metrics instant`'s verbose table output now prints Prometheus labels in a stable, sorted order instead of Go's randomized map iteration order."
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [231]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  Part of an audit into non-deterministic key/array ordering in CLI output (see docs/code-style.md's
+  "Deterministic output ordering" section for the pattern and the guardrail added against recurrence).
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with "chore" or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Default: '[user]'
+change_logs: []

--- a/docs/code-style.md
+++ b/docs/code-style.md
@@ -93,9 +93,11 @@ for _, k := range keys {
 **What this rule does *not* cover:** marshalling a struct or a `map[string]interface{}` through `encoding/json`, `sigs.k8s.io/yaml`, or `gopkg.in/yaml.v3` is already deterministic — all three sort object/map keys internally before writing them out, so `formatter.PrintYAML`/`PrintJSON` and `sigsyaml.Marshal` (used throughout `internal/asset/diff.go` and every asset command) never need a manual sort.
 The risk is exclusively in hand-written loops that touch a map *before* the data reaches one of those marshallers.
 
-**What this rule cannot fix:** array/slice fields are never reordered by a marshaller — a JSON array's element order is preserved verbatim.
+**What this rule cannot fix by itself:** array/slice fields are never reordered by a marshaller — a JSON array's element order is preserved verbatim.
 When the Dash0 API itself returns a semantically-unordered field as an array (e.g. `spec.permissions`, dashboard `spec.panels`) in an order that varies between requests, no client-side sort of *map* keys addresses that, because there's no map to sort — the instability lives in the server response.
-If the CLI ever needs to normalize such a field for a clean diff, the fix is an explicit sort of the decoded slice by a stable key (e.g. panel ID) inserted into `internal/asset/diff.go`'s `marshalForDiff`, not a change to the marshalling call itself.
+When such a field has a natural, stable sort key, normalize it explicitly at the point of display/diff (not in the marshalling call itself).
+`spec.permissions` on views and synthetic checks is the worked example: each entry carries exactly one of `role`/`teamId`/`userId`, so `internal/asset/permissions.go`'s `SortViewPermissions`/`SortSyntheticCheckPermissions` sort lexicographically on whichever is set (mirroring the `dash0.com/sharing` annotation's `role:`/`team:`/`user:` prefixes) and are called from `internal/asset/diff.go`'s `marshalForDiff` (so `create`/`update`/`apply` diffs are stable) and from `views`/`synthetic-checks` `get`/`list` (so exported YAML/JSON is stable too).
+Dashboard `spec.panels` remains unaddressed — panels have no single field that's an obvious, product-agreed identity key, so sorting it needs a design decision rather than a mechanical fix; if one is made, follow the same pattern (a small `Sort*` helper in `internal/asset/`, called from both the diff path and the `get`/`list` export paths).
 
 ## Reference implementations
 

--- a/docs/code-style.md
+++ b/docs/code-style.md
@@ -94,10 +94,15 @@ for _, k := range keys {
 The risk is exclusively in hand-written loops that touch a map *before* the data reaches one of those marshallers.
 
 **What this rule cannot fix by itself:** array/slice fields are never reordered by a marshaller — a JSON array's element order is preserved verbatim.
-When the Dash0 API itself returns a semantically-unordered field as an array (e.g. `spec.permissions`, dashboard `spec.panels`) in an order that varies between requests, no client-side sort of *map* keys addresses that, because there's no map to sort — the instability lives in the server response.
+When the Dash0 API itself returns a semantically-unordered field as an *array* in an order that varies between requests, no client-side sort of *map* keys addresses that, because there's no map to sort — the instability lives in the server response.
 When such a field has a natural, stable sort key, normalize it explicitly at the point of display/diff (not in the marshalling call itself).
 `spec.permissions` on views and synthetic checks is the worked example: each entry carries exactly one of `role`/`teamId`/`userId`, so `internal/asset/permissions.go`'s `SortViewPermissions`/`SortSyntheticCheckPermissions` sort lexicographically on whichever is set (mirroring the `dash0.com/sharing` annotation's `role:`/`team:`/`user:` prefixes) and are called from `internal/asset/diff.go`'s `marshalForDiff` (so `create`/`update`/`apply` diffs are stable) and from `views`/`synthetic-checks` `get`/`list` (so exported YAML/JSON is stable too).
-Dashboard `spec.panels` remains unaddressed — panels have no single field that's an obvious, product-agreed identity key, so sorting it needs a design decision rather than a mechanical fix; if one is made, follow the same pattern (a small `Sort*` helper in `internal/asset/`, called from both the diff path and the `get`/`list` export paths).
+
+Dashboard `spec.panels` looked like the same problem at first glance but isn't: despite the name, `panels` is a JSON *object* keyed by panel ID (`{"<uuid>": {"kind": "Panel", ...}, ...}`), not an array — Dashboard's `Spec` field is `map[string]interface{}`, so `panels` decodes as a nested `map[string]interface{}` too.
+That means it already falls under the "does not cover" paragraph above: `encoding/json` (and therefore `sigs.k8s.io/yaml`, used by every dashboard output path) sorts its keys on every marshal, regardless of what order the server originally sent them in.
+No `Sort*` helper is needed or possible here — there's no array to sort, and the map is already deterministic.
+`TestPrintDiff_Dashboard_PanelKeyOrderIsNotAChange` in `internal/asset/diff_test.go` pins this down as a regression test.
+Before assuming a given API field needs an explicit sort, check whether it's actually a JSON array (needs one, if unordered) or a JSON object (already handled) — the field name alone (`panels`, `permissions`) doesn't tell you which.
 
 ## Reference implementations
 

--- a/docs/code-style.md
+++ b/docs/code-style.md
@@ -67,6 +67,36 @@ All lint issues must be resolved before merging.
 - When asserting on request bodies in integration tests, parse the body into the appropriate typed struct (e.g., `dash0api.DashboardDefinition`, `dash0api.PrometheusAlertRule`, `dash0api.ViewDefinition`, `dash0api.SyntheticCheckDefinition`) and assert on the struct fields.
   Do not use `assert.Contains` on the raw JSON string — substring matching is fragile and can match unrelated fields or partial values.
 
+## Deterministic output ordering
+
+Go randomizes map iteration order on every process run.
+Any code that builds user-facing output (table rows, hand-assembled strings, CSV cells, or a struct that later gets marshalled) by doing `for k, v := range someMap { ... }` and printing/appending as it goes will therefore emit the same logical data in a different order from one invocation to the next, even with byte-identical input.
+This is invisible in a single manual test run and shows up as flaky diffs, flaky golden-file tests, or (per [issue #231](https://github.com/dash0hq/dash0-cli/issues/231)) noisy `apply`/`get` round-trips once a user or CI script starts comparing output across runs.
+
+**The rule:** never range over a map directly to build output.
+Collect its keys into a slice, `sort.Strings` (or the appropriate typed sort) it, then range the sorted slice:
+
+```go
+keys := make([]string, 0, len(m))
+for k := range m {
+    keys = append(keys, k)
+}
+sort.Strings(keys)
+for _, k := range keys {
+    fmt.Printf("  %s: %s\n", k, m[k])
+}
+```
+
+`internal/otlp/proxy_tail.go` (`writeAttributes`, `renderMap`) and `internal/rawapi/api_cmd.go` (`writeHeaders`) already follow this pattern — copy them rather than reinventing it.
+`internal/metrics/shared.go`'s `renderInstantTable` verbose format was the one place that didn't, ranging directly over a `map[string]string` of Prometheus labels; it was fixed as part of closing issue #231 and is a good before/after reference if you need one.
+
+**What this rule does *not* cover:** marshalling a struct or a `map[string]interface{}` through `encoding/json`, `sigs.k8s.io/yaml`, or `gopkg.in/yaml.v3` is already deterministic — all three sort object/map keys internally before writing them out, so `formatter.PrintYAML`/`PrintJSON` and `sigsyaml.Marshal` (used throughout `internal/asset/diff.go` and every asset command) never need a manual sort.
+The risk is exclusively in hand-written loops that touch a map *before* the data reaches one of those marshallers.
+
+**What this rule cannot fix:** array/slice fields are never reordered by a marshaller — a JSON array's element order is preserved verbatim.
+When the Dash0 API itself returns a semantically-unordered field as an array (e.g. `spec.permissions`, dashboard `spec.panels`) in an order that varies between requests, no client-side sort of *map* keys addresses that, because there's no map to sort — the instability lives in the server response.
+If the CLI ever needs to normalize such a field for a clean diff, the fix is an explicit sort of the decoded slice by a stable key (e.g. panel ID) inserted into `internal/asset/diff.go`'s `marshalForDiff`, not a change to the marshalling call itself.
+
 ## Reference implementations
 
 When implementing a new command, use the following packages as templates for each command type:

--- a/internal/asset/diff.go
+++ b/internal/asset/diff.go
@@ -43,6 +43,7 @@ func marshalForDiff(asset any) (string, error) {
 			return "", fmt.Errorf("failed to unmarshal view: %w", err)
 		}
 		dash0api.StripViewServerFields(&v)
+		SortViewPermissions(&v)
 		stripped = &v
 	case *dash0api.SyntheticCheckDefinition:
 		var c dash0api.SyntheticCheckDefinition
@@ -50,6 +51,7 @@ func marshalForDiff(asset any) (string, error) {
 			return "", fmt.Errorf("failed to unmarshal synthetic check: %w", err)
 		}
 		dash0api.StripSyntheticCheckServerFields(&c)
+		SortSyntheticCheckPermissions(&c)
 		stripped = &c
 	case *dash0api.SpamFilter:
 		var s dash0api.SpamFilter

--- a/internal/asset/diff_test.go
+++ b/internal/asset/diff_test.go
@@ -189,6 +189,43 @@ func TestPrintDiff_StripsServerFields_View(t *testing.T) {
 	assert.Contains(t, buf.String(), `View "Error Logs": no changes`)
 }
 
+// TestPrintDiff_View_PermissionOrderIsNotAChange guards against issue #231:
+// the server does not guarantee a stable order for spec.permissions, so a
+// before/after pair that only differs in permission order must not render as
+// a change.
+func TestPrintDiff_View_PermissionOrderIsNotAChange(t *testing.T) {
+	dashcolor.NoColor = true
+	defer func() { dashcolor.NoColor = false }()
+
+	before := &dash0api.ViewDefinition{
+		Kind:     "View",
+		Metadata: dash0api.ViewMetadata{Name: "Error Logs"},
+		Spec: dash0api.ViewSpec{
+			Display: dash0api.ViewDisplay{},
+			Permissions: &[]dash0api.ViewPermission{
+				{Role: strPtr("basic_member")},
+				{Role: strPtr("admin")},
+			},
+		},
+	}
+	after := &dash0api.ViewDefinition{
+		Kind:     "View",
+		Metadata: dash0api.ViewMetadata{Name: "Error Logs"},
+		Spec: dash0api.ViewSpec{
+			Display: dash0api.ViewDisplay{},
+			Permissions: &[]dash0api.ViewPermission{
+				{Role: strPtr("admin")},
+				{Role: strPtr("basic_member")},
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	err := PrintDiff(&buf, "View", "Error Logs", before, after)
+	require.NoError(t, err)
+	assert.Contains(t, buf.String(), `View "Error Logs": no changes`)
+}
+
 func TestPrintDiff_ColorOutput(t *testing.T) {
 	dashcolor.NoColor = false
 	t.Setenv("CLICOLOR_FORCE", "1")

--- a/internal/asset/diff_test.go
+++ b/internal/asset/diff_test.go
@@ -2,6 +2,7 @@ package asset
 
 import (
 	"bytes"
+	"encoding/json"
 	"testing"
 	"time"
 
@@ -38,6 +39,47 @@ func TestPrintDiff_NoChanges(t *testing.T) {
 	err := PrintDiff(&buf, "Dashboard", "My Dashboard", dashboard, same)
 	require.NoError(t, err)
 	assert.Contains(t, buf.String(), `Dashboard "My Dashboard": no changes`)
+}
+
+// TestPrintDiff_Dashboard_PanelKeyOrderIsNotAChange guards against issue #231.
+// spec.panels is a JSON object keyed by panel ID, not an array, so unlike
+// spec.permissions it needs no explicit sort: encoding/json (used by
+// sigs.k8s.io/yaml under marshalForDiff) already sorts map keys on every
+// marshal, regardless of what order the two source documents' panel keys
+// were in.
+func TestPrintDiff_Dashboard_PanelKeyOrderIsNotAChange(t *testing.T) {
+	dashcolor.NoColor = true
+	defer func() { dashcolor.NoColor = false }()
+
+	beforeJSON := `{
+		"kind": "Dashboard",
+		"metadata": {"name": "test"},
+		"spec": {
+			"panels": {
+				"zzz-panel": {"kind": "Panel", "spec": {"display": {"name": "Z"}}},
+				"aaa-panel": {"kind": "Panel", "spec": {"display": {"name": "A"}}}
+			}
+		}
+	}`
+	afterJSON := `{
+		"kind": "Dashboard",
+		"metadata": {"name": "test"},
+		"spec": {
+			"panels": {
+				"aaa-panel": {"kind": "Panel", "spec": {"display": {"name": "A"}}},
+				"zzz-panel": {"kind": "Panel", "spec": {"display": {"name": "Z"}}}
+			}
+		}
+	}`
+
+	var before, after dash0api.DashboardDefinition
+	require.NoError(t, json.Unmarshal([]byte(beforeJSON), &before))
+	require.NoError(t, json.Unmarshal([]byte(afterJSON), &after))
+
+	var buf bytes.Buffer
+	err := PrintDiff(&buf, "Dashboard", "test", &before, &after)
+	require.NoError(t, err)
+	assert.Contains(t, buf.String(), `Dashboard "test": no changes`)
 }
 
 func TestPrintDiff_WithChanges(t *testing.T) {

--- a/internal/asset/permissions.go
+++ b/internal/asset/permissions.go
@@ -1,0 +1,52 @@
+package asset
+
+import (
+	"sort"
+
+	dash0api "github.com/dash0hq/dash0-api-client-go"
+)
+
+// permissionSortKey returns a deterministic sort key for a single permission
+// entry, built from whichever of role/team/user is set. Exactly one of the
+// three is expected to be present per entry; the prefixes mirror the
+// `dash0.com/sharing` annotation format ("role:...", "team:...", "user:...").
+func permissionSortKey(role, teamId, userId *string) string {
+	switch {
+	case role != nil:
+		return "role:" + *role
+	case teamId != nil:
+		return "team:" + *teamId
+	case userId != nil:
+		return "user:" + *userId
+	default:
+		return ""
+	}
+}
+
+// SortViewPermissions sorts a view's spec.permissions lexicographically.
+// The server does not guarantee a stable order for this field (see issue
+// #231), so the CLI normalizes it before display or diffing to avoid
+// spurious reordering noise across repeated get/apply cycles.
+func SortViewPermissions(view *dash0api.ViewDefinition) {
+	if view == nil || view.Spec.Permissions == nil {
+		return
+	}
+	perms := *view.Spec.Permissions
+	sort.SliceStable(perms, func(i, j int) bool {
+		return permissionSortKey(perms[i].Role, perms[i].TeamId, perms[i].UserId) <
+			permissionSortKey(perms[j].Role, perms[j].TeamId, perms[j].UserId)
+	})
+}
+
+// SortSyntheticCheckPermissions is the SyntheticCheck equivalent of
+// SortViewPermissions.
+func SortSyntheticCheckPermissions(check *dash0api.SyntheticCheckDefinition) {
+	if check == nil || check.Spec.Permissions == nil {
+		return
+	}
+	perms := *check.Spec.Permissions
+	sort.SliceStable(perms, func(i, j int) bool {
+		return permissionSortKey(perms[i].Role, perms[i].TeamId, perms[i].UserId) <
+			permissionSortKey(perms[j].Role, perms[j].TeamId, perms[j].UserId)
+	})
+}

--- a/internal/asset/permissions_test.go
+++ b/internal/asset/permissions_test.go
@@ -1,0 +1,87 @@
+package asset
+
+import (
+	"testing"
+
+	dash0api "github.com/dash0hq/dash0-api-client-go"
+	"github.com/stretchr/testify/assert"
+)
+
+func strPtr(s string) *string { return &s }
+
+func TestSortViewPermissions_SortsLexicographically(t *testing.T) {
+	view := &dash0api.ViewDefinition{
+		Spec: dash0api.ViewSpec{
+			Permissions: &[]dash0api.ViewPermission{
+				{Role: strPtr("basic_member"), Actions: []dash0api.ViewAction{dash0api.ViewsRead}},
+				{TeamId: strPtr("team_123"), Actions: []dash0api.ViewAction{dash0api.ViewsRead}},
+				{Role: strPtr("admin"), Actions: []dash0api.ViewAction{dash0api.ViewsWrite}},
+				{UserId: strPtr("alice@example.com"), Actions: []dash0api.ViewAction{dash0api.ViewsRead}},
+			},
+		},
+	}
+
+	SortViewPermissions(view)
+
+	perms := *view.Spec.Permissions
+	assert.Equal(t, "admin", *perms[0].Role)
+	assert.Equal(t, "basic_member", *perms[1].Role)
+	assert.Equal(t, "team_123", *perms[2].TeamId)
+	assert.Equal(t, "alice@example.com", *perms[3].UserId)
+}
+
+func TestSortViewPermissions_StableOrderRegardlessOfInputOrder(t *testing.T) {
+	buildAndSort := func(order []dash0api.ViewPermission) []dash0api.ViewPermission {
+		view := &dash0api.ViewDefinition{Spec: dash0api.ViewSpec{Permissions: &order}}
+		SortViewPermissions(view)
+		return *view.Spec.Permissions
+	}
+
+	a := dash0api.ViewPermission{Role: strPtr("admin")}
+	b := dash0api.ViewPermission{Role: strPtr("basic_member")}
+	c := dash0api.ViewPermission{TeamId: strPtr("team_123")}
+
+	sortedOne := buildAndSort([]dash0api.ViewPermission{a, b, c})
+	sortedTwo := buildAndSort([]dash0api.ViewPermission{c, a, b})
+	sortedThree := buildAndSort([]dash0api.ViewPermission{b, c, a})
+
+	assert.Equal(t, sortedOne, sortedTwo)
+	assert.Equal(t, sortedOne, sortedThree)
+}
+
+func TestSortViewPermissions_NilSafe(t *testing.T) {
+	assert.NotPanics(t, func() { SortViewPermissions(nil) })
+
+	view := &dash0api.ViewDefinition{}
+	assert.NotPanics(t, func() { SortViewPermissions(view) })
+	assert.Nil(t, view.Spec.Permissions)
+}
+
+func TestSortSyntheticCheckPermissions_SortsLexicographically(t *testing.T) {
+	check := &dash0api.SyntheticCheckDefinition{
+		Spec: dash0api.SyntheticCheckSpec{
+			Permissions: &[]dash0api.SyntheticCheckPermission{
+				{Role: strPtr("basic_member")},
+				{TeamId: strPtr("team_123")},
+				{Role: strPtr("admin")},
+				{UserId: strPtr("alice@example.com")},
+			},
+		},
+	}
+
+	SortSyntheticCheckPermissions(check)
+
+	perms := *check.Spec.Permissions
+	assert.Equal(t, "admin", *perms[0].Role)
+	assert.Equal(t, "basic_member", *perms[1].Role)
+	assert.Equal(t, "team_123", *perms[2].TeamId)
+	assert.Equal(t, "alice@example.com", *perms[3].UserId)
+}
+
+func TestSortSyntheticCheckPermissions_NilSafe(t *testing.T) {
+	assert.NotPanics(t, func() { SortSyntheticCheckPermissions(nil) })
+
+	check := &dash0api.SyntheticCheckDefinition{}
+	assert.NotPanics(t, func() { SortSyntheticCheckPermissions(check) })
+	assert.Nil(t, check.Spec.Permissions)
+}

--- a/internal/metrics/shared.go
+++ b/internal/metrics/shared.go
@@ -242,8 +242,13 @@ func renderInstantTable(response *QueryInstantResponse, cols []query.ColumnDef, 
 	// Verbose label-per-line format (backwards compatible with the original metrics instant output).
 	for _, result := range response.Data.Result {
 		fmt.Println("Metric:")
-		for k, v := range result.Metric {
-			fmt.Printf("  %s: %s\n", k, v)
+		keys := make([]string, 0, len(result.Metric))
+		for k := range result.Metric {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, k := range keys {
+			fmt.Printf("  %s: %s\n", k, result.Metric[k])
 		}
 		if len(result.Value) >= 2 {
 			fmt.Printf("Value: %v\n", result.Value[1])

--- a/internal/syntheticchecks/get.go
+++ b/internal/syntheticchecks/get.go
@@ -55,6 +55,7 @@ func runGet(ctx context.Context, id string, flags *asset.GetFlags) error {
 	}
 
 	dash0api.SetSyntheticCheckIDIfAbsent(check, id)
+	asset.SortSyntheticCheckPermissions(check)
 
 	format, err := output.ParseFormat(flags.Output)
 	if err != nil {

--- a/internal/syntheticchecks/list.go
+++ b/internal/syntheticchecks/list.go
@@ -112,6 +112,7 @@ func fetchFullSyntheticChecks(
 			return nil, fmt.Errorf("failed to fetch synthetic check %q: %w", item.Id, err)
 		}
 		dash0api.SetSyntheticCheckIDIfAbsent(check, item.Id)
+		asset.SortSyntheticCheckPermissions(check)
 		definitions = append(definitions, check)
 	}
 	return definitions, nil

--- a/internal/views/get.go
+++ b/internal/views/get.go
@@ -55,6 +55,7 @@ func runGet(ctx context.Context, id string, flags *asset.GetFlags) error {
 	}
 
 	dash0api.SetViewIDIfAbsent(view, id)
+	asset.SortViewPermissions(view)
 
 	format, err := output.ParseFormat(flags.Output)
 	if err != nil {

--- a/internal/views/list.go
+++ b/internal/views/list.go
@@ -112,6 +112,7 @@ func fetchFullViews(
 			return nil, fmt.Errorf("failed to fetch view %q: %w", item.Id, err)
 		}
 		dash0api.SetViewIDIfAbsent(view, item.Id)
+		asset.SortViewPermissions(view)
 		definitions = append(definitions, view)
 	}
 	return definitions, nil


### PR DESCRIPTION
Audited the codebase for non-deterministic map-key iteration and found one live instance: renderInstantTable's verbose format ranged directly over a map[string]string of Prometheus labels, so label order varied between runs of the same query.

Documented the pattern and the already-correct examples elsewhere in the codebase (proxy_tail.go, api_cmd.go) in docs/code-style.md so future code doesn't reintroduce it, and clarified what the rule does and doesn't cover (struct/map marshalling via encoding/json, sigs.k8s.io/yaml, and gopkg.in/yaml.v3 already sorts map keys; array/slice order from the API is untouched by any marshaller and would need an explicit sort in internal/asset/diff.go if the CLI ever needs to normalize it).

Fixes #231