### PR TITLE
feat(teams): support `teams update -f <file>` for declarative updates

### DIFF
--- a/.agents/skills/dash0-cli/references/teams.md
+++ b/.agents/skills/dash0-cli/references/teams.md
@@ -94,16 +94,71 @@ Aliases: `add`
 
 ### `teams update` (experimental)
 
-Update the display settings of a team (name, color).
+Update a team from a YAML or JSON `TeamDefinitionV1Alpha1` document.
 
 ```bash
-dash0 -X teams update <id> [--name <name>] [--color-from <hex>] [--color-to <hex>]
+dash0 -X teams update [<id>] -f <file> [--dry-run]
 ```
 
-Example:
+The file must have the same shape `teams create -f` accepts and `teams get -o yaml` produces, so the export → edit → reapply loop round-trips cleanly.
+If the positional `<id>` argument is omitted, the CLI derives the target team from the document's `dash0.com/origin` label (preferred) or `dash0.com/id` label — matching the upsert-key precedence in the [Asset identifiers and idempotent upsert](#asset-identifiers-and-idempotent-upsert) section.
+When both a positional `<id>` and one of the labels are present, the argument must match the origin or the id in the file; otherwise the command fails before any API call.
+
+Unlike `teams create -f`, `teams update -f` does not create a new team on 404 — the team must already exist.
+The output is a unified diff of the before and after states, with `spec.members` rendered as email addresses so membership changes are legible.
+
+Use `-f -` to read from stdin.
+The `--dry-run` flag prints the diff without applying the update.
+
+Update a team from a file (id resolved from the file's `dash0.com/origin` or `dash0.com/id`):
+
+```bash
+$ dash0 -X teams update -f team.yaml
+--- Team (before)
++++ Team (after)
+@@ -2,7 +2,7 @@
+ spec:
+   display:
+-    name: Backend Team
++    name: Backend Team (renamed)
+```
+
+Update using an explicit id (validated against the file's origin/id):
+
+```bash
+dash0 -X teams update <id> -f team.yaml
+```
+
+Update from stdin (the `cat … | dash0 …` pipeline counts as one command):
+
+```bash
+cat team.yaml | dash0 -X teams update -f -
+```
+
+Preview the diff without mutating:
+
+```bash
+dash0 -X teams update -f team.yaml --dry-run
+```
+
+Export → edit → reapply (idempotent when the YAML is unchanged):
+
+```bash
+$ dash0 -X teams get <id> -o yaml > team.yaml
+$ # edit team.yaml, then:
+$ dash0 -X teams update -f team.yaml
+Team "Backend Team": no changes
+```
+
+#### Deprecated: imperative flags
+
+The pre-existing imperative flags — `--name`, `--color-from`, `--color-to` — are deprecated in favor of `-f/--file`, but continue to work for backward compatibility.
+Each use prints a one-line deprecation warning to stderr.
+The imperative form can only mutate the team's display settings; `spec.members` and other fields require `-f`.
 
 ```bash
 $ dash0 -X teams update <id> --name "New Team Name"
+Flag --name has been deprecated, use -f/--file with a TeamDefinitionV1Alpha1 document instead
 Team "<id>" updated
 ```
 

--- a/.chloggen/worktree-team-update-f.yaml
+++ b/.chloggen/worktree-team-update-f.yaml
@@ -1,0 +1,28 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern (e.g. dashboards, config, apply)
+component: teams
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "`teams update` now accepts `-f <file>` with a TeamDefinitionV1Alpha1 document, enabling the export → edit → reapply workflow every other asset kind already supports."
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [237]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  The imperative `--name`, `--color-from`, and `--color-to` flags keep working for backward compatibility but are now deprecated in favor of `-f`.
+  Unlike `teams create -f`, `teams update -f` does not create a team on 404 — the target must already exist.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with "chore" or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Default: '[user]'
+change_logs: []

--- a/.claude/skills/dash0-cli/references/teams.md
+++ b/.claude/skills/dash0-cli/references/teams.md
@@ -94,16 +94,71 @@ Aliases: `add`
 
 ### `teams update` (experimental)
 
-Update the display settings of a team (name, color).
+Update a team from a YAML or JSON `TeamDefinitionV1Alpha1` document.
 
 ```bash
-dash0 -X teams update <id> [--name <name>] [--color-from <hex>] [--color-to <hex>]
+dash0 -X teams update [<id>] -f <file> [--dry-run]
 ```
 
-Example:
+The file must have the same shape `teams create -f` accepts and `teams get -o yaml` produces, so the export → edit → reapply loop round-trips cleanly.
+If the positional `<id>` argument is omitted, the CLI derives the target team from the document's `dash0.com/origin` label (preferred) or `dash0.com/id` label — matching the upsert-key precedence in the [Asset identifiers and idempotent upsert](#asset-identifiers-and-idempotent-upsert) section.
+When both a positional `<id>` and one of the labels are present, the argument must match the origin or the id in the file; otherwise the command fails before any API call.
+
+Unlike `teams create -f`, `teams update -f` does not create a new team on 404 — the team must already exist.
+The output is a unified diff of the before and after states, with `spec.members` rendered as email addresses so membership changes are legible.
+
+Use `-f -` to read from stdin.
+The `--dry-run` flag prints the diff without applying the update.
+
+Update a team from a file (id resolved from the file's `dash0.com/origin` or `dash0.com/id`):
+
+```bash
+$ dash0 -X teams update -f team.yaml
+--- Team (before)
++++ Team (after)
+@@ -2,7 +2,7 @@
+ spec:
+   display:
+-    name: Backend Team
++    name: Backend Team (renamed)
+```
+
+Update using an explicit id (validated against the file's origin/id):
+
+```bash
+dash0 -X teams update <id> -f team.yaml
+```
+
+Update from stdin (the `cat … | dash0 …` pipeline counts as one command):
+
+```bash
+cat team.yaml | dash0 -X teams update -f -
+```
+
+Preview the diff without mutating:
+
+```bash
+dash0 -X teams update -f team.yaml --dry-run
+```
+
+Export → edit → reapply (idempotent when the YAML is unchanged):
+
+```bash
+$ dash0 -X teams get <id> -o yaml > team.yaml
+$ # edit team.yaml, then:
+$ dash0 -X teams update -f team.yaml
+Team "Backend Team": no changes
+```
+
+#### Deprecated: imperative flags
+
+The pre-existing imperative flags — `--name`, `--color-from`, `--color-to` — are deprecated in favor of `-f/--file`, but continue to work for backward compatibility.
+Each use prints a one-line deprecation warning to stderr.
+The imperative form can only mutate the team's display settings; `spec.members` and other fields require `-f`.
 
 ```bash
 $ dash0 -X teams update <id> --name "New Team Name"
+Flag --name has been deprecated, use -f/--file with a TeamDefinitionV1Alpha1 document instead
 Team "<id>" updated
 ```
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -2291,16 +2291,71 @@ Aliases: `add`
 
 ### `teams update` (experimental)
 
-Update the display settings of a team (name, color).
+Update a team from a YAML or JSON `TeamDefinitionV1Alpha1` document.
 
 ```bash
-dash0 -X teams update <id> [--name <name>] [--color-from <hex>] [--color-to <hex>]
+dash0 -X teams update [<id>] -f <file> [--dry-run]
 ```
 
-Example:
+The file must have the same shape `teams create -f` accepts and `teams get -o yaml` produces, so the export → edit → reapply loop round-trips cleanly.
+If the positional `<id>` argument is omitted, the CLI derives the target team from the document's `dash0.com/origin` label (preferred) or `dash0.com/id` label — matching the upsert-key precedence in the [Asset identifiers and idempotent upsert](#asset-identifiers-and-idempotent-upsert) section.
+When both a positional `<id>` and one of the labels are present, the argument must match the origin or the id in the file; otherwise the command fails before any API call.
+
+Unlike `teams create -f`, `teams update -f` does not create a new team on 404 — the team must already exist.
+The output is a unified diff of the before and after states, with `spec.members` rendered as email addresses so membership changes are legible.
+
+Use `-f -` to read from stdin.
+The `--dry-run` flag prints the diff without applying the update.
+
+Update a team from a file (id resolved from the file's `dash0.com/origin` or `dash0.com/id`):
+
+```bash
+$ dash0 -X teams update -f team.yaml
+--- Team (before)
++++ Team (after)
+@@ -2,7 +2,7 @@
+ spec:
+   display:
+-    name: Backend Team
++    name: Backend Team (renamed)
+```
+
+Update using an explicit id (validated against the file's origin/id):
+
+```bash
+dash0 -X teams update <id> -f team.yaml
+```
+
+Update from stdin (the `cat … | dash0 …` pipeline counts as one command):
+
+```bash
+cat team.yaml | dash0 -X teams update -f -
+```
+
+Preview the diff without mutating:
+
+```bash
+dash0 -X teams update -f team.yaml --dry-run
+```
+
+Export → edit → reapply (idempotent when the YAML is unchanged):
+
+```bash
+$ dash0 -X teams get <id> -o yaml > team.yaml
+$ # edit team.yaml, then:
+$ dash0 -X teams update -f team.yaml
+Team "Backend Team": no changes
+```
+
+#### Deprecated: imperative flags
+
+The pre-existing imperative flags — `--name`, `--color-from`, `--color-to` — are deprecated in favor of `-f/--file`, but continue to work for backward compatibility.
+Each use prints a one-line deprecation warning to stderr.
+The imperative form can only mutate the team's display settings; `spec.members` and other fields require `-f`.
 
 ```bash
 $ dash0 -X teams update <id> --name "New Team Name"
+Flag --name has been deprecated, use -f/--file with a TeamDefinitionV1Alpha1 document instead
 Team "<id>" updated
 ```
 

--- a/internal/skill/content/references/teams.md
+++ b/internal/skill/content/references/teams.md
@@ -94,16 +94,71 @@ Aliases: `add`
 
 ### `teams update` (experimental)
 
-Update the display settings of a team (name, color).
+Update a team from a YAML or JSON `TeamDefinitionV1Alpha1` document.
 
 ```bash
-dash0 -X teams update <id> [--name <name>] [--color-from <hex>] [--color-to <hex>]
+dash0 -X teams update [<id>] -f <file> [--dry-run]
 ```
 
-Example:
+The file must have the same shape `teams create -f` accepts and `teams get -o yaml` produces, so the export → edit → reapply loop round-trips cleanly.
+If the positional `<id>` argument is omitted, the CLI derives the target team from the document's `dash0.com/origin` label (preferred) or `dash0.com/id` label — matching the upsert-key precedence in the [Asset identifiers and idempotent upsert](#asset-identifiers-and-idempotent-upsert) section.
+When both a positional `<id>` and one of the labels are present, the argument must match the origin or the id in the file; otherwise the command fails before any API call.
+
+Unlike `teams create -f`, `teams update -f` does not create a new team on 404 — the team must already exist.
+The output is a unified diff of the before and after states, with `spec.members` rendered as email addresses so membership changes are legible.
+
+Use `-f -` to read from stdin.
+The `--dry-run` flag prints the diff without applying the update.
+
+Update a team from a file (id resolved from the file's `dash0.com/origin` or `dash0.com/id`):
+
+```bash
+$ dash0 -X teams update -f team.yaml
+--- Team (before)
++++ Team (after)
+@@ -2,7 +2,7 @@
+ spec:
+   display:
+-    name: Backend Team
++    name: Backend Team (renamed)
+```
+
+Update using an explicit id (validated against the file's origin/id):
+
+```bash
+dash0 -X teams update <id> -f team.yaml
+```
+
+Update from stdin (the `cat … | dash0 …` pipeline counts as one command):
+
+```bash
+cat team.yaml | dash0 -X teams update -f -
+```
+
+Preview the diff without mutating:
+
+```bash
+dash0 -X teams update -f team.yaml --dry-run
+```
+
+Export → edit → reapply (idempotent when the YAML is unchanged):
+
+```bash
+$ dash0 -X teams get <id> -o yaml > team.yaml
+$ # edit team.yaml, then:
+$ dash0 -X teams update -f team.yaml
+Team "Backend Team": no changes
+```
+
+#### Deprecated: imperative flags
+
+The pre-existing imperative flags — `--name`, `--color-from`, `--color-to` — are deprecated in favor of `-f/--file`, but continue to work for backward compatibility.
+Each use prints a one-line deprecation warning to stderr.
+The imperative form can only mutate the team's display settings; `spec.members` and other fields require `-f`.
 
 ```bash
 $ dash0 -X teams update <id> --name "New Team Name"
+Flag --name has been deprecated, use -f/--file with a TeamDefinitionV1Alpha1 document instead
 Team "<id>" updated
 ```
 

--- a/internal/teams/integration_test.go
+++ b/internal/teams/integration_test.go
@@ -1162,7 +1162,7 @@ spec:
 
 	err = cmd.Execute()
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "no team id provided as argument")
+	assert.Contains(t, err.Error(), "no team ID provided as argument")
 	assert.Empty(t, server.Requests(), "missing addressor must fail before any API call")
 }
 

--- a/internal/teams/integration_test.go
+++ b/internal/teams/integration_test.go
@@ -887,3 +887,498 @@ func TestRemoveMembers_ForceContinuesOn404Across(t *testing.T) {
 	assert.Contains(t, stdout, "user_member2")
 	assert.Contains(t, stdout, "removed from team")
 }
+
+// countRequests returns the number of recorded requests matching the given
+// method and path.
+func countRequests(requests []testutil.RecordedRequest, method, path string) int {
+	n := 0
+	for _, req := range requests {
+		if req.Method == method && req.Path == path {
+			n++
+		}
+	}
+	return n
+}
+
+// TestUpdateTeam_Imperative_Name backfills coverage for the pre-existing
+// imperative code path (--name). The flag is deprecated but still routes
+// through GetTeam → merge display → PUT /display, unchanged from before
+// issue #237.
+func TestUpdateTeam_Imperative_Name(t *testing.T) {
+	testutil.SetupTestEnv(t)
+
+	const teamID = "a1b2c3d4-5678-90ab-cdef-1234567890ab"
+	teamsIDPattern := regexp.MustCompile(`^/api/teams/[^/]+$`)
+
+	server := testutil.NewMockServer(t, testutil.FixturesDir())
+	server.OnPattern(http.MethodGet, teamsIDPattern, testutil.MockResponse{
+		StatusCode: http.StatusOK,
+		BodyFile:   testutil.FixtureTeamsGetSuccess,
+		Validator:  testutil.RequireHeaders,
+	})
+	server.OnPattern(http.MethodPut, regexp.MustCompile(`^/api/teams/[^/]+/display$`), testutil.MockResponse{
+		// Server accepts 200 OK or 204 No Content per the OpenAPI spec.
+		// The generated response parser unconditionally unmarshals the body
+		// into ErrorResponse when Content-Type is JSON — 204 with a stripped
+		// body crashes on "unexpected end of JSON input", so use 200 with
+		// an empty JSON object.
+		StatusCode: http.StatusOK,
+		Body:       map[string]any{},
+		Validator:  testutil.RequireHeaders,
+	})
+
+	cmd := newExperimentalTeamsCmd()
+	cmd.SetArgs([]string{"-X", "teams", "update", teamID, "--name", "New Team Name", "--api-url", server.URL, "--auth-token", testAuthToken})
+
+	var err error
+	output := testutil.CaptureStdout(t, func() {
+		err = cmd.Execute()
+	})
+
+	require.NoError(t, err)
+	assert.Contains(t, output, "updated")
+	assert.Equal(t, 1, countRequests(server.Requests(), http.MethodPut, "/api/teams/"+teamID+"/display"),
+		"imperative --name must land on the /display sub-endpoint, not the top-level upsert")
+}
+
+// TestUpdateTeamFromFile_ByID exercises `teams update <id> -f <file>` where
+// the file's dash0.com/id matches the positional argument. Asserts the
+// canonical GET → PUT flow: the fetch validates existence, then the full
+// document lands via UpsertTeam.
+func TestUpdateTeamFromFile_ByID(t *testing.T) {
+	testutil.SetupTestEnv(t)
+
+	const teamID = "a1b2c3d4-5678-90ab-cdef-1234567890ab"
+	teamsIDPattern := regexp.MustCompile(`^/api/teams/[^/]+$`)
+
+	server := testutil.NewMockServer(t, testutil.FixturesDir())
+	server.OnPattern(http.MethodGet, teamsIDPattern, testutil.MockResponse{
+		StatusCode: http.StatusOK,
+		BodyFile:   testutil.FixtureTeamsGetSuccess,
+		Validator:  testutil.RequireHeaders,
+	})
+	server.OnPattern(http.MethodPut, teamsIDPattern, testutil.MockResponse{
+		StatusCode: http.StatusOK,
+		BodyFile:   testutil.FixtureTeamsCreateSuccess,
+		Validator:  testutil.RequireHeaders,
+	})
+
+	tmpDir := t.TempDir()
+	yamlFile := filepath.Join(tmpDir, "team.yaml")
+	err := os.WriteFile(yamlFile, []byte(`apiVersion: dash0.com/v1alpha1
+kind: Dash0Team
+metadata:
+  name: backend-team
+  labels:
+    dash0.com/id: `+teamID+`
+spec:
+  display:
+    name: Renamed Team
+    color:
+      from: "#111111"
+      to: "#222222"
+  members: []
+`), 0644)
+	require.NoError(t, err)
+
+	cmd := newExperimentalTeamsCmd()
+	cmd.SetArgs([]string{"-X", "teams", "update", teamID, "-f", yamlFile, "--api-url", server.URL, "--auth-token", testAuthToken})
+
+	testutil.CaptureStdout(t, func() {
+		err = cmd.Execute()
+	})
+	require.NoError(t, err)
+
+	assertPUTPath(t, server.Requests(), "/api/teams/"+teamID, "expected PUT-by-id after preflight GET")
+	assert.Equal(t, 1, countRequests(server.Requests(), http.MethodPut, "/api/teams/"+teamID),
+		"file-based update must not hit the /display sub-endpoint")
+	assert.Equal(t, 0, countRequests(server.Requests(), http.MethodPut, "/api/teams/"+teamID+"/display"),
+		"file-based update must not fall through to UpdateTeamDisplay")
+}
+
+// TestUpdateTeamFromFile_ByOrigin covers the case where the file names an
+// origin and the positional argument is the same origin. GET-by-origin then
+// PUT-by-origin, matching the ImportTeam routing.
+func TestUpdateTeamFromFile_ByOrigin(t *testing.T) {
+	testutil.SetupTestEnv(t)
+
+	const origin = "backend-team-origin"
+	teamsPattern := regexp.MustCompile(`^/api/teams/[^/]+$`)
+
+	server := testutil.NewMockServer(t, testutil.FixturesDir())
+	server.OnPattern(http.MethodGet, teamsPattern, testutil.MockResponse{
+		StatusCode: http.StatusOK,
+		BodyFile:   testutil.FixtureTeamsGetSuccess,
+		Validator:  testutil.RequireHeaders,
+	})
+	server.OnPattern(http.MethodPut, teamsPattern, testutil.MockResponse{
+		StatusCode: http.StatusOK,
+		BodyFile:   testutil.FixtureTeamsCreateSuccess,
+		Validator:  testutil.RequireHeaders,
+	})
+
+	tmpDir := t.TempDir()
+	yamlFile := filepath.Join(tmpDir, "team.yaml")
+	err := os.WriteFile(yamlFile, []byte(`apiVersion: dash0.com/v1alpha1
+kind: Dash0Team
+metadata:
+  name: backend-team
+  labels:
+    dash0.com/origin: `+origin+`
+spec:
+  display:
+    name: Renamed Team
+    color:
+      from: "#111111"
+      to: "#222222"
+  members: []
+`), 0644)
+	require.NoError(t, err)
+
+	cmd := newExperimentalTeamsCmd()
+	cmd.SetArgs([]string{"-X", "teams", "update", origin, "-f", yamlFile, "--api-url", server.URL, "--auth-token", testAuthToken})
+
+	testutil.CaptureStdout(t, func() {
+		err = cmd.Execute()
+	})
+	require.NoError(t, err)
+
+	assertPUTPath(t, server.Requests(), "/api/teams/"+origin, "expected PUT-by-origin")
+}
+
+// TestUpdateTeamFromFile_IDFromFile omits the positional argument and lets
+// the CLI derive the addressor from the file. Origin wins over id, matching
+// asset.ImportTeam.
+func TestUpdateTeamFromFile_IDFromFile(t *testing.T) {
+	testutil.SetupTestEnv(t)
+
+	const origin = "backend-team-origin"
+	const teamID = "a1b2c3d4-5678-90ab-cdef-1234567890ab"
+	teamsPattern := regexp.MustCompile(`^/api/teams/[^/]+$`)
+
+	server := testutil.NewMockServer(t, testutil.FixturesDir())
+	server.OnPattern(http.MethodGet, teamsPattern, testutil.MockResponse{
+		StatusCode: http.StatusOK,
+		BodyFile:   testutil.FixtureTeamsGetSuccess,
+		Validator:  testutil.RequireHeaders,
+	})
+	server.OnPattern(http.MethodPut, teamsPattern, testutil.MockResponse{
+		StatusCode: http.StatusOK,
+		BodyFile:   testutil.FixtureTeamsCreateSuccess,
+		Validator:  testutil.RequireHeaders,
+	})
+
+	tmpDir := t.TempDir()
+	yamlFile := filepath.Join(tmpDir, "team.yaml")
+	err := os.WriteFile(yamlFile, []byte(`apiVersion: dash0.com/v1alpha1
+kind: Dash0Team
+metadata:
+  name: backend-team
+  labels:
+    dash0.com/origin: `+origin+`
+    dash0.com/id: `+teamID+`
+spec:
+  display:
+    name: Renamed Team
+    color:
+      from: "#111111"
+      to: "#222222"
+  members: []
+`), 0644)
+	require.NoError(t, err)
+
+	cmd := newExperimentalTeamsCmd()
+	cmd.SetArgs([]string{"-X", "teams", "update", "-f", yamlFile, "--api-url", server.URL, "--auth-token", testAuthToken})
+
+	testutil.CaptureStdout(t, func() {
+		err = cmd.Execute()
+	})
+	require.NoError(t, err)
+
+	assertPUTPath(t, server.Requests(), "/api/teams/"+origin, "origin must win over id when both are present in the file")
+}
+
+// TestUpdateTeamFromFile_ArgFileMismatch pins the safety check that stops
+// an operator from applying a file to the wrong team by mistake. The mock
+// server records nothing — the failure is client-side, before any API call.
+func TestUpdateTeamFromFile_ArgFileMismatch(t *testing.T) {
+	testutil.SetupTestEnv(t)
+
+	server := testutil.NewMockServer(t, testutil.FixturesDir())
+
+	tmpDir := t.TempDir()
+	yamlFile := filepath.Join(tmpDir, "team.yaml")
+	err := os.WriteFile(yamlFile, []byte(`apiVersion: dash0.com/v1alpha1
+kind: Dash0Team
+metadata:
+  name: backend-team
+  labels:
+    dash0.com/id: file-id-1111-2222-3333-444444444444
+spec:
+  display:
+    name: Renamed Team
+    color:
+      from: "#111111"
+      to: "#222222"
+  members: []
+`), 0644)
+	require.NoError(t, err)
+
+	cmd := newExperimentalTeamsCmd()
+	cmd.SetArgs([]string{"-X", "teams", "update", "arg-id-aaaa-bbbb-cccc-dddddddddddd", "-f", yamlFile, "--api-url", server.URL, "--auth-token", testAuthToken})
+
+	err = cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "does not match")
+	assert.Contains(t, err.Error(), "arg-id-aaaa-bbbb-cccc-dddddddddddd")
+	assert.Contains(t, err.Error(), "file-id-1111-2222-3333-444444444444")
+	assert.Empty(t, server.Requests(), "mismatch must fail before any API call")
+}
+
+// TestUpdateTeamFromFile_NoIDAnywhere pins the empty-addressor case.
+func TestUpdateTeamFromFile_NoIDAnywhere(t *testing.T) {
+	testutil.SetupTestEnv(t)
+
+	server := testutil.NewMockServer(t, testutil.FixturesDir())
+
+	tmpDir := t.TempDir()
+	yamlFile := filepath.Join(tmpDir, "team.yaml")
+	err := os.WriteFile(yamlFile, []byte(`apiVersion: dash0.com/v1alpha1
+kind: Dash0Team
+metadata:
+  name: backend-team
+spec:
+  display:
+    name: Renamed Team
+    color:
+      from: "#111111"
+      to: "#222222"
+  members: []
+`), 0644)
+	require.NoError(t, err)
+
+	cmd := newExperimentalTeamsCmd()
+	cmd.SetArgs([]string{"-X", "teams", "update", "-f", yamlFile, "--api-url", server.URL, "--auth-token", testAuthToken})
+
+	err = cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no team id provided as argument")
+	assert.Empty(t, server.Requests(), "missing addressor must fail before any API call")
+}
+
+// TestUpdateTeamFromFile_NotFound asserts that `teams update -f` fails
+// cleanly when the team does not exist. This is the semantic that
+// distinguishes `update` from `create`/`apply` — the update endpoint must
+// not create a new team on 404.
+func TestUpdateTeamFromFile_NotFound(t *testing.T) {
+	testutil.SetupTestEnv(t)
+
+	const teamID = "a1b2c3d4-5678-90ab-cdef-1234567890ab"
+	teamsIDPattern := regexp.MustCompile(`^/api/teams/[^/]+$`)
+
+	server := testutil.NewMockServer(t, testutil.FixturesDir())
+	server.OnPattern(http.MethodGet, teamsIDPattern, testutil.MockResponse{
+		StatusCode: http.StatusNotFound,
+		BodyFile:   testutil.FixtureTeamsNotFound,
+		Validator:  testutil.RequireHeaders,
+	})
+
+	tmpDir := t.TempDir()
+	yamlFile := filepath.Join(tmpDir, "team.yaml")
+	err := os.WriteFile(yamlFile, []byte(`apiVersion: dash0.com/v1alpha1
+kind: Dash0Team
+metadata:
+  name: backend-team
+  labels:
+    dash0.com/id: `+teamID+`
+spec:
+  display:
+    name: Renamed Team
+    color:
+      from: "#111111"
+      to: "#222222"
+  members: []
+`), 0644)
+	require.NoError(t, err)
+
+	cmd := newExperimentalTeamsCmd()
+	cmd.SetArgs([]string{"-X", "teams", "update", teamID, "-f", yamlFile, "--api-url", server.URL, "--auth-token", testAuthToken})
+
+	err = cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not found")
+
+	// No PUT must have been attempted.
+	for _, req := range server.Requests() {
+		assert.NotEqual(t, http.MethodPut, req.Method, "update must not PUT after a 404 preflight")
+	}
+}
+
+// TestUpdateTeamFromFile_RejectsImperativeFlags asserts that combining -f
+// with any of the deprecated imperative flags is a usage error.
+func TestUpdateTeamFromFile_RejectsImperativeFlags(t *testing.T) {
+	testutil.SetupTestEnv(t)
+
+	server := testutil.NewMockServer(t, testutil.FixturesDir())
+
+	tmpDir := t.TempDir()
+	yamlFile := filepath.Join(tmpDir, "team.yaml")
+	err := os.WriteFile(yamlFile, []byte(`apiVersion: dash0.com/v1alpha1
+kind: Dash0Team
+metadata:
+  name: backend-team
+  labels:
+    dash0.com/id: a1b2c3d4-5678-90ab-cdef-1234567890ab
+spec:
+  display:
+    name: Renamed Team
+    color:
+      from: "#111111"
+      to: "#222222"
+  members: []
+`), 0644)
+	require.NoError(t, err)
+
+	cmd := newExperimentalTeamsCmd()
+	cmd.SetArgs([]string{"-X", "teams", "update", "-f", yamlFile, "--name", "collision", "--api-url", server.URL, "--auth-token", testAuthToken})
+
+	err = cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cannot combine -f/--file")
+	assert.Empty(t, server.Requests(), "usage error must fail before any API call")
+}
+
+// TestUpdateTeamFromFile_DryRun asserts that --dry-run prints a diff and
+// does not PUT the team.
+func TestUpdateTeamFromFile_DryRun(t *testing.T) {
+	testutil.SetupTestEnv(t)
+
+	const teamID = "a1b2c3d4-5678-90ab-cdef-1234567890ab"
+	teamsIDPattern := regexp.MustCompile(`^/api/teams/[^/]+$`)
+
+	server := testutil.NewMockServer(t, testutil.FixturesDir())
+	server.OnPattern(http.MethodGet, teamsIDPattern, testutil.MockResponse{
+		StatusCode: http.StatusOK,
+		BodyFile:   testutil.FixtureTeamsGetSuccess,
+		Validator:  testutil.RequireHeaders,
+	})
+	// Members list may or may not be called for email resolution; register
+	// a permissive handler so the dry-run path is not blocked on missing routes.
+	server.On(http.MethodGet, apiPathMembers, testutil.MockResponse{
+		StatusCode: http.StatusOK,
+		BodyFile:   testutil.FixtureMembersListSuccess,
+		Validator:  testutil.RequireHeaders,
+	})
+
+	tmpDir := t.TempDir()
+	yamlFile := filepath.Join(tmpDir, "team.yaml")
+	err := os.WriteFile(yamlFile, []byte(`apiVersion: dash0.com/v1alpha1
+kind: Dash0Team
+metadata:
+  name: backend-team
+  labels:
+    dash0.com/id: `+teamID+`
+spec:
+  display:
+    name: A Completely Different Name
+    color:
+      from: "#111111"
+      to: "#222222"
+  members: []
+`), 0644)
+	require.NoError(t, err)
+
+	cmd := newExperimentalTeamsCmd()
+	cmd.SetArgs([]string{"-X", "teams", "update", teamID, "-f", yamlFile, "--dry-run", "--api-url", server.URL, "--auth-token", testAuthToken})
+
+	output := testutil.CaptureStdout(t, func() {
+		err = cmd.Execute()
+	})
+	require.NoError(t, err)
+
+	assert.Contains(t, output, "A Completely Different Name",
+		"dry-run should surface the incoming display name in the diff")
+
+	// Zero PUTs — dry-run must not mutate.
+	for _, req := range server.Requests() {
+		assert.NotEqual(t, http.MethodPut, req.Method, "dry-run must not PUT")
+	}
+}
+
+// TestUpdateTeamFromFile_Idempotent_NoOpWhenUnchanged is the mock-server
+// analogue of the roundtrip test's Step 4a/4b: reapplying a YAML that
+// matches the server-side state (once server-managed fields are stripped)
+// must print "no changes" — no spurious diff hunks from server-echoed
+// annotations, upsert key hints, or member id/email drift.
+func TestUpdateTeamFromFile_Idempotent_NoOpWhenUnchanged(t *testing.T) {
+	testutil.SetupTestEnv(t)
+
+	// Mock server returns the same envelope from both GET and PUT, standing
+	// in for the real backend echoing the request body back.
+	const teamID = "a1b2c3d4-5678-90ab-cdef-1234567890ab"
+	teamsIDPattern := regexp.MustCompile(`^/api/teams/[^/]+$`)
+
+	server := testutil.NewMockServer(t, testutil.FixturesDir())
+	server.OnPattern(http.MethodGet, teamsIDPattern, testutil.MockResponse{
+		StatusCode: http.StatusOK,
+		BodyFile:   testutil.FixtureTeamsGetSuccess,
+		Validator:  testutil.RequireHeaders,
+	})
+	// PUT echoes the same team back — the envelope-only shape UpsertTeam
+	// expects. This has to match get_success.json's inner .team content so
+	// PrintDiff renders "no changes"; a fresh fixture is needed because
+	// get_success is wrapped in {team, members, ...} and create_success has
+	// different content.
+	server.OnPattern(http.MethodPut, teamsIDPattern, testutil.MockResponse{
+		StatusCode: http.StatusOK,
+		BodyFile:   "teams/upsert_echo.json",
+		Validator:  testutil.RequireHeaders,
+	})
+	server.On(http.MethodGet, apiPathMembers, testutil.MockResponse{
+		StatusCode: http.StatusOK,
+		BodyFile:   testutil.FixtureMembersListSuccess,
+		Validator:  testutil.RequireHeaders,
+	})
+
+	// Input mirrors the server's canonical team shape — same display name,
+	// same color, same members — with server-managed annotations that
+	// StripTeamServerFields must drop.
+	tmpDir := t.TempDir()
+	yamlFile := filepath.Join(tmpDir, "team.yaml")
+	err := os.WriteFile(yamlFile, []byte(`apiVersion: dash0.com/v1alpha1
+kind: Dash0Team
+metadata:
+  name: backend-team
+  labels:
+    dash0.com/id: `+teamID+`
+    dash0.com/origin: dash0-cli
+  annotations:
+    dash0.com/created-at: "2025-01-01T00:00:00Z"
+    dash0.com/updated-at: "2025-01-02T00:00:00Z"
+spec:
+  display:
+    name: Backend Team
+    color:
+      from: "#FF6B6B"
+      to: "#4ECDC4"
+  members:
+    - m1-0000-0000-0000-000000000001
+    - m2-0000-0000-0000-000000000002
+`), 0644)
+	require.NoError(t, err)
+
+	cmd := newExperimentalTeamsCmd()
+	cmd.SetArgs([]string{"-X", "teams", "update", teamID, "-f", yamlFile, "--api-url", server.URL, "--auth-token", testAuthToken})
+
+	output := testutil.CaptureStdout(t, func() {
+		err = cmd.Execute()
+	})
+	require.NoError(t, err)
+
+	assert.Contains(t, output, "no changes",
+		"reapplying an unchanged YAML must render as no-op — server-managed annotations must be stripped and not leak into the diff")
+	assert.NotContains(t, output, "dash0.com/created-at",
+		"server-managed annotations must not appear in the rendered diff")
+	assert.NotContains(t, output, "dash0.com/updated-at",
+		"server-managed annotations must not appear in the rendered diff")
+}

--- a/internal/teams/update.go
+++ b/internal/teams/update.go
@@ -117,11 +117,11 @@ func runUpdateFromFile(ctx context.Context, args []string, flags *updateFlags) e
 			if addressor != fileOrigin && addressor != fileID {
 				switch {
 				case fileOrigin != "" && fileID != "":
-					return fmt.Errorf("the id argument %q does not match dash0.com/origin %q or dash0.com/id %q in the file", addressor, fileOrigin, fileID)
+					return fmt.Errorf("the ID argument %q does not match dash0.com/origin %q or dash0.com/id %q in the file", addressor, fileOrigin, fileID)
 				case fileOrigin != "":
-					return fmt.Errorf("the id argument %q does not match dash0.com/origin %q in the file", addressor, fileOrigin)
+					return fmt.Errorf("the ID argument %q does not match dash0.com/origin %q in the file", addressor, fileOrigin)
 				default:
-					return fmt.Errorf("the id argument %q does not match dash0.com/id %q in the file", addressor, fileID)
+					return fmt.Errorf("the ID argument %q does not match dash0.com/id %q in the file", addressor, fileID)
 				}
 			}
 		}
@@ -132,7 +132,7 @@ func runUpdateFromFile(ctx context.Context, args []string, flags *updateFlags) e
 			addressor = fileID
 		}
 		if addressor == "" {
-			return fmt.Errorf("no team id provided as argument, and the file does not contain a dash0.com/origin or dash0.com/id label")
+			return fmt.Errorf("no team ID provided as argument, and the file does not contain a dash0.com/origin or dash0.com/id label")
 		}
 	}
 

--- a/internal/teams/update.go
+++ b/internal/teams/update.go
@@ -1,10 +1,13 @@
 package teams
 
 import (
+	"context"
 	"fmt"
+	"os"
 
 	dash0api "github.com/dash0hq/dash0-api-client-go"
 	"github.com/dash0hq/dash0-cli/internal"
+	"github.com/dash0hq/dash0-cli/internal/asset"
 	"github.com/dash0hq/dash0-cli/internal/client"
 	"github.com/dash0hq/dash0-cli/internal/experimental"
 	"github.com/spf13/cobra"
@@ -13,6 +16,8 @@ import (
 type updateFlags struct {
 	ApiUrl    string
 	AuthToken string
+	File      string
+	DryRun    bool
 	Name      string
 	ColorFrom string
 	ColorTo   string
@@ -22,41 +27,170 @@ func newUpdateCmd() *cobra.Command {
 	flags := &updateFlags{}
 
 	cmd := &cobra.Command{
-		Use:   "update <id>",
+		Use:   "update [<id>] -f <file>",
 		Short: "[experimental] Update a team",
-		Long: `Update the display settings of a team (name, color).
+		Long: `Update a team from a YAML or JSON TeamDefinitionV1Alpha1 document.
 
-Flags that are not provided leave the corresponding field unchanged; the CLI
-fetches the current display, merges your changes, and PUTs the result.` + internal.CONFIG_HINT,
-		Example: `  # Rename a team, keeping its current color gradient
-  dash0 --experimental teams update <id> --name "New Name"
+The file must have the same shape ` + "`teams create -f`" + ` accepts and
+` + "`teams get -o yaml`" + ` produces, so the export → edit → reapply loop
+round-trips cleanly. If the positional <id> argument is omitted, the CLI
+derives the target team from the document's dash0.com/origin label (preferred)
+or dash0.com/id label. Use '-f -' to read from stdin.
 
-  # Update the team's color gradient without touching the name
-  dash0 --experimental teams update <id> \
-      --color-from "#FF0000" --color-to "#00FF00"`,
-		Args: cobra.ExactArgs(1),
+The team must already exist; unlike ` + "`teams create -f`" + `, ` + "`update`" + ` does not
+create a new team on 404.
+
+The imperative --name, --color-from, and --color-to flags are still accepted
+for backward compatibility but are deprecated in favor of -f.` + internal.CONFIG_HINT,
+		Example: `  # Update a team from a file
+  dash0 --experimental teams update -f team.yaml
+
+  # Update using an explicit id (validated against the file's origin/id)
+  dash0 --experimental teams update <id> -f team.yaml
+
+  # Update from stdin
+  cat team.yaml | dash0 --experimental teams update -f -
+
+  # Preview the diff without mutating
+  dash0 --experimental teams update -f team.yaml --dry-run
+
+  # Export, edit, reapply
+  dash0 --experimental teams get <id> -o yaml > team.yaml
+  # edit team.yaml
+  dash0 --experimental teams update -f team.yaml`,
+		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := experimental.RequireExperimental(cmd); err != nil {
 				return err
 			}
-			return runUpdate(cmd, args[0], flags)
+			return runUpdate(cmd.Context(), args, flags)
 		},
 	}
 
 	cmd.Flags().StringVar(&flags.ApiUrl, "api-url", "", "API endpoint URL (overrides active profile)")
 	cmd.Flags().StringVar(&flags.AuthToken, "auth-token", "", "Auth token (overrides active profile)")
-	cmd.Flags().StringVar(&flags.Name, "name", "", "New team name")
-	cmd.Flags().StringVar(&flags.ColorFrom, "color-from", "", "Gradient start color (e.g. \"#FF0000\")")
-	cmd.Flags().StringVar(&flags.ColorTo, "color-to", "", "Gradient end color (e.g. \"#00FF00\")")
+	cmd.Flags().StringVarP(&flags.File, "file", "f", "", "Path to YAML or JSON definition file (use '-' for stdin)")
+	cmd.Flags().BoolVar(&flags.DryRun, "dry-run", false, "Print the diff without applying (declarative mode only)")
+	cmd.Flags().StringVar(&flags.Name, "name", "", "New team name (imperative mode)")
+	cmd.Flags().StringVar(&flags.ColorFrom, "color-from", "", "Gradient start color, e.g. \"#FF0000\" (imperative mode)")
+	cmd.Flags().StringVar(&flags.ColorTo, "color-to", "", "Gradient end color, e.g. \"#00FF00\" (imperative mode)")
+	_ = cmd.Flags().MarkDeprecated("name", "use -f/--file with a TeamDefinitionV1Alpha1 document instead")
+	_ = cmd.Flags().MarkDeprecated("color-from", "use -f/--file with a TeamDefinitionV1Alpha1 document instead")
+	_ = cmd.Flags().MarkDeprecated("color-to", "use -f/--file with a TeamDefinitionV1Alpha1 document instead")
 
 	return cmd
 }
 
-func runUpdate(cmd *cobra.Command, originOrID string, flags *updateFlags) error {
-	ctx := cmd.Context()
+func runUpdate(ctx context.Context, args []string, flags *updateFlags) error {
+	if flags.File != "" {
+		if flags.Name != "" || flags.ColorFrom != "" || flags.ColorTo != "" {
+			return fmt.Errorf("cannot combine -f/--file with --name, --color-from, or --color-to")
+		}
+		return runUpdateFromFile(ctx, args, flags)
+	}
+	if flags.DryRun {
+		return fmt.Errorf("--dry-run is only valid with -f/--file")
+	}
+	if len(args) != 1 {
+		return fmt.Errorf("either -f/--file or a positional <id> argument is required")
+	}
+	return runUpdateImperative(ctx, args[0], flags)
+}
 
+func runUpdateFromFile(ctx context.Context, args []string, flags *updateFlags) error {
+	var team dash0api.TeamDefinitionV1Alpha1
+	if err := asset.ReadDefinition(flags.File, &team, os.Stdin); err != nil {
+		return fmt.Errorf("failed to read team definition: %w", err)
+	}
+
+	fileOrigin := dash0api.GetTeamOrigin(&team)
+	fileID := dash0api.GetTeamID(&team)
+
+	var addressor string
+	if len(args) == 1 {
+		addressor = args[0]
+		// Consistency check: if the file names an origin or id, the positional
+		// argument must equal one of them. This is the analogue of the check
+		// in `views update` and `dashboards update`, adapted for the fact that
+		// a team YAML can carry two identifiers.
+		if fileOrigin != "" || fileID != "" {
+			if addressor != fileOrigin && addressor != fileID {
+				switch {
+				case fileOrigin != "" && fileID != "":
+					return fmt.Errorf("the id argument %q does not match dash0.com/origin %q or dash0.com/id %q in the file", addressor, fileOrigin, fileID)
+				case fileOrigin != "":
+					return fmt.Errorf("the id argument %q does not match dash0.com/origin %q in the file", addressor, fileOrigin)
+				default:
+					return fmt.Errorf("the id argument %q does not match dash0.com/id %q in the file", addressor, fileID)
+				}
+			}
+		}
+	} else {
+		// Origin wins over id, mirroring asset.ImportTeam's routing.
+		addressor = fileOrigin
+		if addressor == "" {
+			addressor = fileID
+		}
+		if addressor == "" {
+			return fmt.Errorf("no team id provided as argument, and the file does not contain a dash0.com/origin or dash0.com/id label")
+		}
+	}
+
+	apiClient, err := client.NewClientFromContext(ctx, flags.ApiUrl, flags.AuthToken)
+	if err != nil {
+		return err
+	}
+
+	before, err := apiClient.GetTeam(ctx, addressor)
+	if err != nil {
+		return client.HandleAPIError(err, client.ErrorContext{
+			AssetType: "team",
+			AssetID:   addressor,
+		})
+	}
+
+	// Strip server-managed labels and annotations from the request body.
+	// A YAML exported via `teams get -o yaml` will carry dash0.com/created-at,
+	// dash0.com/updated-at, and dash0.com/id — leaving them in place either
+	// gets rejected by the server or makes the diff render spurious changes.
+	// This matches how ImportTeam and views update prepare the payload.
+	dash0api.StripTeamServerFields(&team)
+
+	displayName := dash0api.GetTeamDisplayName(&team)
+	if displayName == "" {
+		displayName = dash0api.GetTeamName(&team)
+	}
+
+	if flags.DryRun {
+		// Resolve members to emails for a legible diff. Failures are non-fatal;
+		// raw ids in the diff are still readable, just less friendly.
+		_ = dash0api.ResolveTeamMembersToEmails(ctx, apiClient, before)
+		_ = dash0api.ResolveTeamMembersToEmails(ctx, apiClient, &team)
+		return asset.PrintDiff(os.Stdout, "Team", displayName, before, &team)
+	}
+
+	result, err := apiClient.UpsertTeam(ctx, addressor, &team)
+	if err != nil {
+		return client.HandleAPIError(err, client.ErrorContext{
+			AssetType: "team",
+			AssetID:   addressor,
+			AssetName: displayName,
+		})
+	}
+
+	_ = dash0api.ResolveTeamMembersToEmails(ctx, apiClient, before)
+	_ = dash0api.ResolveTeamMembersToEmails(ctx, apiClient, result)
+
+	resultName := dash0api.GetTeamDisplayName(result)
+	if resultName == "" {
+		resultName = dash0api.GetTeamName(result)
+	}
+	return asset.PrintDiff(os.Stdout, "Team", resultName, before, result)
+}
+
+func runUpdateImperative(ctx context.Context, originOrID string, flags *updateFlags) error {
 	if flags.Name == "" && flags.ColorFrom == "" && flags.ColorTo == "" {
-		return fmt.Errorf("nothing to update: pass at least one of --name, --color-from, --color-to")
+		return fmt.Errorf("nothing to update: pass -f/--file or at least one of --name, --color-from, --color-to")
 	}
 
 	apiClient, err := client.NewClientFromContext(ctx, flags.ApiUrl, flags.AuthToken)

--- a/internal/teams/update.go
+++ b/internal/teams/update.go
@@ -88,11 +88,11 @@ func runUpdate(ctx context.Context, args []string, flags *updateFlags) error {
 		}
 		return runUpdateFromFile(ctx, args, flags)
 	}
-	if flags.DryRun {
-		return fmt.Errorf("--dry-run is only valid with -f/--file")
-	}
 	if len(args) != 1 {
 		return fmt.Errorf("either -f/--file or a positional <id> argument is required")
+	}
+	if flags.DryRun {
+		return fmt.Errorf("--dry-run is only valid with -f/--file")
 	}
 	return runUpdateImperative(ctx, args[0], flags)
 }

--- a/internal/teams/update.go
+++ b/internal/teams/update.go
@@ -113,17 +113,8 @@ func runUpdateFromFile(ctx context.Context, args []string, flags *updateFlags) e
 		// argument must equal one of them. This is the analogue of the check
 		// in `views update` and `dashboards update`, adapted for the fact that
 		// a team YAML can carry two identifiers.
-		if fileOrigin != "" || fileID != "" {
-			if addressor != fileOrigin && addressor != fileID {
-				switch {
-				case fileOrigin != "" && fileID != "":
-					return fmt.Errorf("the ID argument %q does not match dash0.com/origin %q or dash0.com/id %q in the file", addressor, fileOrigin, fileID)
-				case fileOrigin != "":
-					return fmt.Errorf("the ID argument %q does not match dash0.com/origin %q in the file", addressor, fileOrigin)
-				default:
-					return fmt.Errorf("the ID argument %q does not match dash0.com/id %q in the file", addressor, fileID)
-				}
-			}
+		if (fileOrigin != "" || fileID != "") && addressor != fileOrigin && addressor != fileID {
+			return fmt.Errorf("the ID argument %q does not match the dash0.com/origin or dash0.com/id label in the file (origin=%q, id=%q)", addressor, fileOrigin, fileID)
 		}
 	} else {
 		// Origin wins over id, mirroring asset.ImportTeam's routing.

--- a/internal/teams/update.go
+++ b/internal/teams/update.go
@@ -27,7 +27,7 @@ func newUpdateCmd() *cobra.Command {
 	flags := &updateFlags{}
 
 	cmd := &cobra.Command{
-		Use:   "update [<id>] -f <file>",
+		Use:   "update [id] -f <file>",
 		Short: "[experimental] Update a team",
 		Long: `Update a team from a YAML or JSON TeamDefinitionV1Alpha1 document.
 

--- a/internal/testutil/fixtures/teams/upsert_echo.json
+++ b/internal/testutil/fixtures/teams/upsert_echo.json
@@ -1,0 +1,23 @@
+{
+  "kind": "Team",
+  "metadata": {
+    "name": "backend-team",
+    "labels": {
+      "dash0.com/id": "a1b2c3d4-5678-90ab-cdef-1234567890ab",
+      "dash0.com/origin": "dash0-cli"
+    }
+  },
+  "spec": {
+    "display": {
+      "name": "Backend Team",
+      "color": {
+        "from": "#FF6B6B",
+        "to": "#4ECDC4"
+      }
+    },
+    "members": [
+      "m1-0000-0000-0000-000000000001",
+      "m2-0000-0000-0000-000000000002"
+    ]
+  }
+}

--- a/test/roundtrip/test_team_declarative_roundtrip.sh
+++ b/test/roundtrip/test_team_declarative_roundtrip.sh
@@ -125,6 +125,148 @@ if ! echo "$EXPORTED_JSON" | jq -e --arg e "$MEMBER_EMAIL_2" '.spec.members | an
   exit 1
 fi
 
+# --- Steps 4a–4e: teams update -f idempotency coverage ---
+# The `teams update -f` path must behave like every other CRUD update:
+# reapplying an unchanged YAML is a no-op, a genuine edit lands cleanly with
+# a single before/after diff, and updates against a missing team fail fast
+# without creating a duplicate. Step 5 below exercises `apply -f`, which is
+# a distinct code path — these 4a–4e steps pin `teams update -f` itself.
+
+# Step 4a: Reapply the same fixture used to create the team. Since the
+# server-side state is identical, PrintDiff should render "no changes" and
+# no diff hunks should appear on stdout.
+echo "--- Step 4a: teams update -f with the create-time fixture is a no-op ---"
+if ! REAPPLY_UPDATE_OUTPUT=$("$DASH0" -X teams update -f "$FIXTURE"); then
+  echo "FAIL: teams update -f with unchanged fixture failed"
+  exit 1
+fi
+echo "$REAPPLY_UPDATE_OUTPUT"
+if ! echo "$REAPPLY_UPDATE_OUTPUT" | grep -q "no changes"; then
+  echo "FAIL: expected 'no changes' from teams update -f with unchanged fixture, got:"
+  echo "$REAPPLY_UPDATE_OUTPUT"
+  exit 1
+fi
+if echo "$REAPPLY_UPDATE_OUTPUT" | grep -qE '^\+\+\+|^---|^@@'; then
+  echo "FAIL: teams update -f with unchanged fixture rendered a diff hunk"
+  exit 1
+fi
+POST_4A_JSON=$("$DASH0" -X teams get "$TEAM_ID" -o json)
+POST_4A_NAME=$(echo "$POST_4A_JSON" | jq -r '.spec.display.name')
+POST_4A_MEMBER_COUNT=$(echo "$POST_4A_JSON" | jq '.spec.members | length')
+if [ "$POST_4A_NAME" != "$DISPLAY_NAME" ] || [ "$POST_4A_MEMBER_COUNT" != "2" ]; then
+  echo "FAIL: after no-op update, team state drifted (name=$POST_4A_NAME, members=$POST_4A_MEMBER_COUNT)"
+  exit 1
+fi
+COUNT=$("$DASH0" -X teams list -o json \
+  | jq --arg origin "$ORIGIN" '[.[] | select(.origin == $origin)] | length')
+if [ "$COUNT" != "1" ]; then
+  echo "FAIL: expected exactly 1 team with origin '$ORIGIN' after no-op update, found $COUNT"
+  exit 1
+fi
+
+# Step 4b: Reapply the exported YAML that came straight from `teams get -o yaml`.
+# This carries server-managed annotations (created-at, updated-at, dash0.com/id)
+# that StripTeamServerFields must drop before PUT; otherwise the request is
+# rejected or the diff renderer treats those fields as user-visible changes.
+echo "--- Step 4b: teams update -f with 'teams get -o yaml' output is a no-op ---"
+if ! ROUNDTRIP_OUTPUT=$("$DASH0" -X teams update -f "${TMPDIR}/exported.yaml"); then
+  echo "FAIL: teams update -f with exported YAML failed"
+  exit 1
+fi
+echo "$ROUNDTRIP_OUTPUT"
+if ! echo "$ROUNDTRIP_OUTPUT" | grep -q "no changes"; then
+  echo "FAIL: teams get -o yaml → teams update -f roundtrip is not a no-op:"
+  echo "$ROUNDTRIP_OUTPUT"
+  exit 1
+fi
+
+# Step 4c: A genuine display-name edit must land cleanly. Assert the diff is
+# rendered (so the user can see what changed) and the update did not spawn a
+# duplicate team.
+echo "--- Step 4c: teams update -f applies a real edit ---"
+UPDATED_VIA_UPDATE_NAME="${DISPLAY_NAME} (via update)"
+sed \
+  -e "s|${DISPLAY_NAME}|${UPDATED_VIA_UPDATE_NAME}|" \
+  "$FIXTURE" > "${TMPDIR}/via_update.yaml"
+if ! REAL_EDIT_OUTPUT=$("$DASH0" -X teams update -f "${TMPDIR}/via_update.yaml"); then
+  echo "FAIL: teams update -f with a real edit failed"
+  exit 1
+fi
+echo "$REAL_EDIT_OUTPUT"
+if ! echo "$REAL_EDIT_OUTPUT" | grep -qF "${UPDATED_VIA_UPDATE_NAME}"; then
+  echo "FAIL: real edit output does not mention new display name '${UPDATED_VIA_UPDATE_NAME}'"
+  exit 1
+fi
+POST_4C_JSON=$("$DASH0" -X teams get "$TEAM_ID" -o json)
+POST_4C_NAME=$(echo "$POST_4C_JSON" | jq -r '.spec.display.name')
+if [ "$POST_4C_NAME" != "$UPDATED_VIA_UPDATE_NAME" ]; then
+  echo "FAIL: expected display name '${UPDATED_VIA_UPDATE_NAME}' after update, got '$POST_4C_NAME'"
+  exit 1
+fi
+COUNT=$("$DASH0" -X teams list -o json \
+  | jq --arg origin "$ORIGIN" '[.[] | select(.origin == $origin)] | length')
+if [ "$COUNT" != "1" ]; then
+  echo "FAIL: teams update -f created a duplicate — expected 1 team with origin '$ORIGIN', found $COUNT"
+  exit 1
+fi
+
+# Step 4d: Re-run the same edit immediately. `teams update -f` must be
+# idempotent after a real mutation, not just at steady state.
+echo "--- Step 4d: teams update -f is idempotent after a real edit ---"
+if ! REPEAT_EDIT_OUTPUT=$("$DASH0" -X teams update -f "${TMPDIR}/via_update.yaml"); then
+  echo "FAIL: second teams update -f with same edited YAML failed"
+  exit 1
+fi
+echo "$REPEAT_EDIT_OUTPUT"
+if ! echo "$REPEAT_EDIT_OUTPUT" | grep -q "no changes"; then
+  echo "FAIL: second run of teams update -f with same edited YAML is not a no-op:"
+  echo "$REPEAT_EDIT_OUTPUT"
+  exit 1
+fi
+
+# Step 4e: teams update -f against a nonexistent team (an origin the server
+# has never seen) must fail cleanly and must not silently create a new team.
+# This is the semantic that distinguishes `update` from `create -f`/`apply
+# -f`, which both upsert and would create on 404.
+echo "--- Step 4e: teams update -f against a nonexistent origin fails clean ---"
+MISSING_ORIGIN="cli-roundtrip-missing-${UNIQUE_ID}"
+sed \
+  -e "s|${ORIGIN}|${MISSING_ORIGIN}|" \
+  "$FIXTURE" > "${TMPDIR}/missing.yaml"
+if MISSING_OUTPUT=$("$DASH0" -X teams update -f "${TMPDIR}/missing.yaml" 2>&1); then
+  echo "FAIL: teams update -f against a nonexistent origin must exit non-zero"
+  echo "$MISSING_OUTPUT"
+  exit 1
+fi
+if ! echo "$MISSING_OUTPUT" | grep -qi "not found"; then
+  echo "FAIL: expected 'not found' in error message, got:"
+  echo "$MISSING_OUTPUT"
+  exit 1
+fi
+COUNT=$("$DASH0" -X teams list -o json \
+  | jq --arg origin "$MISSING_ORIGIN" '[.[] | select(.origin == $origin)] | length')
+if [ "$COUNT" != "0" ]; then
+  echo "FAIL: teams update against nonexistent origin '$MISSING_ORIGIN' must not create a team"
+  exit 1
+fi
+COUNT=$("$DASH0" -X teams list -o json \
+  | jq --arg origin "$ORIGIN" '[.[] | select(.origin == $origin)] | length')
+if [ "$COUNT" != "1" ]; then
+  echo "FAIL: expected exactly 1 team with origin '$ORIGIN' after failed update, found $COUNT"
+  exit 1
+fi
+
+# Restore the pre-Step 5 baseline: put the original display name and member
+# set back so the subsequent `apply -f` step observes the state Step 4 left
+# behind. Without this reset, Step 5's edit would run against the (via update)
+# name and its assertions would need to change.
+if ! "$DASH0" -X teams update -f "$FIXTURE" > /dev/null; then
+  echo "FAIL: reset before Step 5 failed"
+  exit 1
+fi
+# Refresh UPDATED_AT baseline — Step 6 asserts the timestamp advanced past this.
+UPDATED_AT=$("$DASH0" -X teams get "$TEAM_ID" -o json | jq -r '.metadata.annotations["dash0.com/updated-at"] // empty')
+
 # Step 5: Rewrite the exported fixture — rename the team and drop the second
 # member — and apply via 'dash0 apply', which must route Dash0Team through
 # the same upsert path.


### PR DESCRIPTION
Closes #237.

## Summary

- Bring `dash0 teams update` in line with every other CRUD update by accepting a `TeamDefinitionV1Alpha1` document via `-f/--file`, unlocking the export → edit → reapply loop that a YAML pulled from `dash0 teams get -o yaml` could not previously round-trip through.
- Keep the imperative `--name`, `--color-from`, `--color-to` flags working for backward compatibility, but mark them deprecated (one-line stderr warning per use).
- **`update -f` is strictly an update, not an upsert.** A 404 on the preflight `GET /api/teams/{originOrID}` surfaces as a clean "team not found" error — so `update -f` stays semantically distinct from `create -f` / `apply -f`, both of which upsert.