### PR TITLE
fix(config): keep the profile's dataset when env credentials are set

### DIFF
--- a/.chloggen/claude_profile-env-precedence.yaml
+++ b/.chloggen/claude_profile-env-precedence.yaml
@@ -1,0 +1,34 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern (e.g. dashboards, config, apply)
+component: config
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Setting `DASH0_AUTH_TOKEN` together with `DASH0_API_URL` or `DASH0_OTLP_URL` no longer discards the rest of the active profile, so the profile's `dataset` reaches the API again."
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [240]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  That combination used to bypass the active profile wholesale, so requests went out with no
+  `dataset` query parameter and the API fell back to `default` — while `dash0 config show` kept
+  reporting the profile's dataset, leaving nothing in the CLI to tell you the two disagreed.
+  Every setting is now resolved on its own, as `docs/commands.md` has always documented: an
+  environment variable overrides only the setting it names, and `otlp-url` and `dataset` keep
+  coming from the profile.
+  `--dataset` and `DASH0_DATASET` are unaffected, and env vars alone still work with no profile
+  configured at all.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with "chore" or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Default: '[user]'
+change_logs: []

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -58,6 +58,10 @@ The CLI resolves each individual setting (`api-url`, `otlp-url`, `auth-token`, `
 2. CLI flags (`--api-url`, `--otlp-url`, `--auth-token`, `--dataset`)
 3. The selected profile (see below)
 
+Each setting is resolved independently.
+Setting `DASH0_AUTH_TOKEN` and `DASH0_API_URL` does not discard the rest of the selected profile: `dataset` and `otlp-url` still come from the profile unless `DASH0_DATASET`, `--dataset`, `DASH0_OTLP_URL`, or `--otlp-url` names them explicitly.
+Run `dash0 config show` to see the effective values and where each one came from.
+
 The profile itself is selected in this order (first match wins):
 
 1. `--profile <name>` flag

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.25.1
 
 require (
 	github.com/cli/browser v1.3.0
-	github.com/dash0hq/dash0-api-client-go v1.18.0
+	github.com/dash0hq/dash0-api-client-go v1.18.1
 	github.com/google/uuid v1.6.0
 	github.com/muesli/termenv v0.16.0
 	github.com/pmezard/go-difflib v1.0.0
@@ -99,5 +99,3 @@ require (
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260526163538-3dc84a4a5aaa // indirect
 	google.golang.org/protobuf v1.36.11 // indirect
 )
-
-replace github.com/dash0hq/dash0-api-client-go => ../../../dash0-api-client-go/.iac_maintainer/profile-env-precedence

--- a/go.mod
+++ b/go.mod
@@ -99,3 +99,5 @@ require (
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260526163538-3dc84a4a5aaa // indirect
 	google.golang.org/protobuf v1.36.11 // indirect
 )
+
+replace github.com/dash0hq/dash0-api-client-go => ../../../dash0-api-client-go/.iac_maintainer/profile-env-precedence

--- a/go.sum
+++ b/go.sum
@@ -11,8 +11,6 @@ github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XL
 github.com/cli/browser v1.3.0 h1:LejqCrpWr+1pRqmEPDGnTZOjsMe7sehifLynZJuqJpo=
 github.com/cli/browser v1.3.0/go.mod h1:HH8s+fOAxjhQoBUAsKuPCbqUuxZDhQ2/aD+SzsEfBTk=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
-github.com/dash0hq/dash0-api-client-go v1.18.0 h1:J27LLjFZYY9kgFMXLv7OvQcBUd+BbkOgRqkTypmQBa0=
-github.com/dash0hq/dash0-api-client-go v1.18.0/go.mod h1:KNGbcgETrEN4m2QPGAorZ9FybTpVg/oi20UEoWGCGlE=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/go.sum
+++ b/go.sum
@@ -11,6 +11,8 @@ github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XL
 github.com/cli/browser v1.3.0 h1:LejqCrpWr+1pRqmEPDGnTZOjsMe7sehifLynZJuqJpo=
 github.com/cli/browser v1.3.0/go.mod h1:HH8s+fOAxjhQoBUAsKuPCbqUuxZDhQ2/aD+SzsEfBTk=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
+github.com/dash0hq/dash0-api-client-go v1.18.1 h1:NhIt93aEj6C0YmVIWODESDbUbUTVwJ0JEFmC7qi54kw=
+github.com/dash0hq/dash0-api-client-go v1.18.1/go.mod h1:KNGbcgETrEN4m2QPGAorZ9FybTpVg/oi20UEoWGCGlE=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/dash0hq/dash0-cli/internal/agentmode"
 	"github.com/dash0hq/dash0-cli/internal/testutil"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestNewClientFromContext_WithEnvVars(t *testing.T) {
@@ -198,8 +199,83 @@ func TestResolveDataset_DefaultFlagOverridesConfig(t *testing.T) {
 }
 
 func TestResolveDataset_NilWithoutContext(t *testing.T) {
+	t.Setenv("DASH0_CONFIG_DIR", t.TempDir())
+	os.Unsetenv("DASH0_DATASET")
+
 	result := ResolveDataset(context.Background(), "")
 	assert.Nil(t, result)
+}
+
+// TestResolveDataset_FromEnvWithoutContext covers the path where the context
+// carries no configuration -- loadConfig() swallowed an error -- but
+// DASH0_DATASET is set. NewClientFromContext still builds a working client
+// from env vars on that path, so the dataset must not silently vanish.
+func TestResolveDataset_FromEnvWithoutContext(t *testing.T) {
+	t.Setenv("DASH0_CONFIG_DIR", t.TempDir())
+	t.Setenv("DASH0_DATASET", "env-dataset")
+
+	result := ResolveDataset(context.Background(), "")
+	require.NotNil(t, result)
+	assert.Equal(t, "env-dataset", *result)
+}
+
+// TestResolveDataset_FromProfileWithoutContext covers the same missing-context
+// path when the dataset comes from the active profile rather than an env var.
+// NewClientFromContext falls back to profiles.ResolveConfiguration here, and
+// ResolveDataset must use the same source or the two disagree.
+func TestResolveDataset_FromProfileWithoutContext(t *testing.T) {
+	t.Setenv("DASH0_CONFIG_DIR", t.TempDir())
+	os.Unsetenv("DASH0_DATASET")
+
+	store, err := profiles.NewStore()
+	require.NoError(t, err)
+	require.NoError(t, store.AddProfile(profiles.Profile{
+		Name: "prod",
+		Configuration: profiles.Configuration{
+			ApiUrl:    "https://api.test.dash0.com",
+			AuthToken: "auth_test-token-12345",
+			Dataset:   "production",
+		},
+	}))
+	require.NoError(t, store.SetActiveProfile("prod"))
+
+	result := ResolveDataset(context.Background(), "")
+	require.NotNil(t, result)
+	assert.Equal(t, "production", *result)
+}
+
+// TestResolveDataset_EnvCredentialsKeepProfileDataset is the regression test
+// for the profile-bypass bug: DASH0_AUTH_TOKEN together with DASH0_API_URL used
+// to discard the active profile wholesale, so the profile's dataset never
+// reached the request and the API fell back to the default dataset -- while
+// `dash0 config show` kept reporting the profile's value.
+func TestResolveDataset_EnvCredentialsKeepProfileDataset(t *testing.T) {
+	t.Setenv("DASH0_CONFIG_DIR", t.TempDir())
+	os.Unsetenv("DASH0_DATASET")
+
+	store, err := profiles.NewStore()
+	require.NoError(t, err)
+	require.NoError(t, store.AddProfile(profiles.Profile{
+		Name: "prod",
+		Configuration: profiles.Configuration{
+			ApiUrl:    "https://api.profile.dash0.com",
+			AuthToken: "auth_profile-token-12345",
+			Dataset:   "production",
+		},
+	}))
+	require.NoError(t, store.SetActiveProfile("prod"))
+
+	t.Setenv("DASH0_API_URL", "https://api.env.dash0.com")
+	t.Setenv("DASH0_AUTH_TOKEN", "auth_env-token-12345")
+
+	cfg, err := profiles.ResolveConfiguration("", "")
+	require.NoError(t, err)
+	assert.Equal(t, "https://api.env.dash0.com", cfg.ApiUrl)
+	assert.Equal(t, "auth_env-token-12345", cfg.AuthToken)
+
+	result := ResolveDataset(profiles.WithConfiguration(context.Background(), cfg), "")
+	require.NotNil(t, result)
+	assert.Equal(t, "production", *result)
 }
 
 func TestNewRawHTTPConfig_DatasetFromEnvWithoutContext(t *testing.T) {

--- a/internal/client/dataset.go
+++ b/internal/client/dataset.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"context"
+	"os"
 
 	dash0api "github.com/dash0hq/dash0-api-client-go"
 	"github.com/dash0hq/dash0-api-client-go/profiles"
@@ -10,13 +11,31 @@ import (
 // ResolveDataset returns the dataset to use for API calls, checking (in order):
 // 1. The CLI flag value (flagDataset)
 // 2. The configuration from context (profile + DASH0_DATASET env var)
+// 3. The DASH0_DATASET env var, then a freshly resolved configuration, when
+// the context carries no configuration at all
 // Returns nil when no dataset is configured or when the dataset is "default",
 // since the API uses "default" implicitly when no dataset parameter is sent.
+//
+// Step 3 exists because [NewClientFromContext] falls back to
+// [profiles.ResolveConfiguration] when the context configuration is missing.
+// Without the same fallback here, a command whose config failed to load would
+// still reach the API with credentials recovered from flags or env vars, but
+// silently without a dataset — so the request would hit the default dataset
+// instead of the configured one.
 func ResolveDataset(ctx context.Context, flagDataset string) *string {
 	if flagDataset != "" {
 		return dash0api.DatasetPtr(flagDataset)
 	}
-	if cfg := profiles.FromContext(ctx); cfg != nil && cfg.Dataset != "" {
+	if cfg := profiles.FromContext(ctx); cfg != nil {
+		if cfg.Dataset != "" {
+			return dash0api.DatasetPtr(cfg.Dataset)
+		}
+		return nil
+	}
+	if envDataset := os.Getenv(profiles.EnvDataset); envDataset != "" {
+		return dash0api.DatasetPtr(envDataset)
+	}
+	if cfg, err := profiles.ResolveConfigurationContext(ctx, "", ""); err == nil && cfg.Dataset != "" {
 		return dash0api.DatasetPtr(cfg.Dataset)
 	}
 	return nil

--- a/internal/config/profiles_test.go
+++ b/internal/config/profiles_test.go
@@ -782,6 +782,10 @@ func TestResolveConfiguration(t *testing.T) {
 
 	// Test OTLP URL only via env vars (no API URL needed)
 	t.Run("With OTLP URL env var only", func(t *testing.T) {
+		// Isolate the config dir: env vars are layered on top of the active
+		// profile field by field, so without isolation this subtest would read
+		// the developer's real ~/.dash0 and inherit that profile's API URL.
+		_ = setupTestConfigDir(t)
 		os.Unsetenv(profiles.EnvApiUrl)
 		os.Setenv(profiles.EnvOtlpUrl, "https://otlp.example.com")
 		os.Setenv(profiles.EnvAuthToken, "env-token")

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -43,7 +43,7 @@ buildGoModule (finalAttrs: {
   # replaced with the real hash: build once, then copy the `got: sha256-...`
   # value from the resulting hash-mismatch error into this field. Re-run after
   # any change to go.mod / go.sum. See the README's "Install with Nix" section.
-  vendorHash = "sha256-CHoHWdoiJnoIKOXPTDinFus10k0OymIzLZRGAmHrqXE=";
+  vendorHash = "sha256-2zA+4PIDbPukMa4GZO2mnt8SHP7YUIUth7N/ATJCA/I=";
 
   # Only the CLI entrypoint is a `main` package; building it explicitly avoids
   # compiling test-only helpers into the output.


### PR DESCRIPTION
`DASH0_AUTH_TOKEN` alongside `DASH0_API_URL` or `DASH0_OTLP_URL` made the API client discard the active profile wholesale, so the profile's dataset never reached the request. `dash0 config show` reported the right dataset throughout and every command exited zero.

Fixes #240