### PR TITLE
fix(checkrules): pick up top-level annotation merge

### DIFF
--- a/.chloggen/checkrule_toplevel_annotations.yaml
+++ b/.chloggen/checkrule_toplevel_annotations.yaml
@@ -1,0 +1,29 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern (e.g. dashboards, config, apply)
+component: check-rules
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Merge a PrometheusRule CRD's top-level `metadata.annotations` into each rule's own annotations, matching the Dash0 Kubernetes operator and Terraform provider
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [245]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  Previously, a common setting defined once at the top level of a multi-rule PrometheusRule document -
+  most importantly `dash0.com/notification-channel-ids` - was silently dropped for any rule that did not
+  repeat it on its own annotations. A rule's own annotations still take precedence when the same key is
+  set in both places. This affects `check-rules create` and `check-rules update` on PrometheusRule CRD
+  input, and `apply`.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with "chore" or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Default: '[user]'
+change_logs: []

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -603,7 +603,8 @@ Dashboard "My Perses Dashboard" created
 
 `check-rules create` also accepts PrometheusRule CRD files.
 Each alerting rule in the CRD is created as a separate check rule (recording rules are skipped).
-The check rule name is composed as `<group name> - <alert name>`, matching the name produced by the Dash0 Kubernetes operator and the Terraform provider for the same CRD:
+The check rule name is composed as `<group name> - <alert name>`, matching the name produced by the Dash0 Kubernetes operator and the Terraform provider for the same CRD.
+The CRD's top-level `metadata.annotations` are merged into every rule it contains (see [PrometheusRule annotation merge](#prometheusrule-annotation-merge)).
 
 ```bash
 $ dash0 check-rules create -f prometheus-rules.yaml
@@ -739,6 +740,131 @@ Notification channels and spam filters are the two exceptions: their server APIs
 
 When `list -o yaml` or `get -o yaml` exports an existing asset, the server-assigned ID is rendered into the correct field, so the export-edit-reapply workflow round-trips through the identifier automatically.
 
+### PrometheusRule annotation merge
+
+A PrometheusRule document's top-level `metadata.annotations` are merged into each alerting rule's own annotations, key by key. A rule that sets the same key wins for that key only, and still inherits the rest.
+Use this to define a common setting once instead of repeating it on every rule in a multi-rule CRD.
+The recurring example is `dash0.com/notification-channel-ids`, whose value is a comma-separated list of notification channel ids (`dash0 notification-channels list` prints the available ids).
+This applies to `check-rules create`, `apply`, and `check-rules update`, though `update` operates on a single check rule and rejects a CRD containing more than one.
+
+Below, `CheckoutHighLatency` inherits the top-level channel and `CheckoutHighErrorRate` replaces it with its own:
+
+```yaml
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: checkout-alerts
+  annotations:
+    dash0.com/notification-channel-ids: ded5721c-2bf0-4a10-ab33-511fef734b0f
+spec:
+  groups:
+    - name: Alerting
+      rules:
+        - alert: CheckoutHighLatency
+          expr: histogram_quantile(0.99, sum by (le) (rate(http_server_request_duration_seconds_bucket{service_name="checkout"}[5m]))) > 1
+        - alert: CheckoutHighErrorRate
+          expr: sum(rate(http_server_request_duration_seconds_count{service_name="checkout", http_response_status_code=~"5.."}[5m])) > 0.1
+          annotations:
+            dash0.com/notification-channel-ids: 56aaacb2-10c6-4cef-8aeb-d7c862ad863e
+```
+
+```bash
+$ dash0 check-rules create -f checkout-alerts.yaml
+Check rule "Alerting - CheckoutHighLatency" created
+Check rule "Alerting - CheckoutHighErrorRate" created
+```
+
+`CheckoutHighLatency` declared no annotations of its own and still carries the top-level channel:
+
+```bash
+$ dash0 check-rules get a1b2c3d4-5678-90ab-cdef-1234567890ab -o yaml
+annotations:
+  dash0.com/notification-channel-ids: ded5721c-2bf0-4a10-ab33-511fef734b0f
+enabled: true
+expression: histogram_quantile(0.99, sum by (le) (rate(http_server_request_duration_seconds_bucket{service_name="checkout"}[5m])))
+  > 1
+id: a1b2c3d4-5678-90ab-cdef-1234567890ab
+name: Alerting - CheckoutHighLatency
+...
+```
+
+#### Annotations that control rule behavior
+
+A few annotations configure how a rule evaluates rather than describing it:
+
+| Annotation | Controls | Also accepted |
+|---|---|---|
+| `dash0-enabled` | whether the rule evaluates at all | |
+| `dash0-threshold-critical` | the critical threshold | `threshold-critical` |
+| `dash0-threshold-degraded` | the degraded threshold | `threshold-degraded` |
+
+These are unprefixed, unlike the `dash0.com/`-prefixed annotations above, so they are easy to mistake for ordinary metadata.
+They inherit and override like any other annotation, so a value set at the top level reaches every rule that does not name its own.
+Setting `dash0-enabled: "false"` there stops all of those rules from firing:
+
+```yaml
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: checkout-defaults
+  annotations:
+    dash0-enabled: "false"
+    dash0-threshold-critical: "5"
+spec:
+  groups:
+    - name: Alerting
+      rules:
+        - alert: InheritsDisabled
+          expr: up == 0
+        - alert: OverridesToEnabled
+          expr: up == 1
+          annotations:
+            dash0-enabled: "true"
+            dash0-threshold-critical: "9"
+```
+
+The critical and degraded thresholds are two separate annotations, so a document can set one at the top level and a rule can set the other.
+Both then apply to that rule.
+Below, the rule inherits a critical threshold of 1000 milliseconds and sets a degraded threshold of 500 milliseconds:
+
+```yaml
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: checkout-latency
+  annotations:
+    dash0-threshold-critical: "1000"
+spec:
+  groups:
+    - name: Alerting
+      rules:
+        - alert: Checkout P99 Latency
+          expr: histogram_quantile(0.99, sum by (le) (rate(http_server_request_duration_seconds_bucket{service_name="checkout"}[5m]))) * 1000 > $__threshold
+          annotations:
+            dash0-threshold-degraded: "500"
+```
+
+```bash
+$ dash0 check-rules get c3d4e5f6-7890-12cd-ef01-345678901bcd -o yaml
+id: c3d4e5f6-7890-12cd-ef01-345678901bcd
+name: Alerting - Checkout P99 Latency
+...
+thresholds:
+  degraded: 500
+  failed: 1000
+```
+
+The check then reports critical above 1000 milliseconds, degraded between 500 and 1000 milliseconds, and healthy below 500 milliseconds.
+A measurement that crosses both thresholds is reported as critical, never as both.
+
+Dash0 evaluates the critical threshold first, so the critical value has to be the more severe one for the comparison used in the expression: the higher number for `>`, the lower number for `<`.
+Swapping them in the rule above, to a critical threshold of 500 and a degraded threshold of 1000, reports critical from 500 milliseconds upwards and never reports degraded at all.
+
+The prefixed and unprefixed spellings of a setting are different annotation keys, and the prefixed one wins wherever both are present.
+That takes precedence over the rule-beats-document behavior above: a rule setting `threshold-critical` does not override a top-level `dash0-threshold-critical`.
+The losing value is not discarded either, it stays on the check rule as an ordinary annotation, which is usually how you notice.
+Use one spelling throughout a document.
+
 ### `apply`
 
 Apply asset definitions from a file, directory, or stdin.
@@ -768,7 +894,7 @@ For `Dash0SpamFilter`, the `apiVersion` field on the document selects the schema
 An unknown value fails validation up front, before any document is applied.
 
 For `PrometheusRule`, `apply` inspects each rule entry and dispatches by type.
-Alerting rules (entries with `alert:`) are sent to the check-rule endpoint as one check rule per alert, named `<group name> - <alert name>` to match the Dash0 Kubernetes operator and the Terraform provider.
+Alerting rules (entries with `alert:`) are sent to the check-rule endpoint as one check rule per alert, named `<group name> - <alert name>` to match the Dash0 Kubernetes operator and the Terraform provider (see [PrometheusRule annotation merge](#prometheusrule-annotation-merge)).
 Recording rules (entries with `record:`) are sent to the recording-rule endpoint as a single PrometheusRule CRD with the alerting rules removed.
 A CRD that mixes both kinds is dispatched to both endpoints in a single apply.
 A CRD that contains no alerting and no recording rules fails validation up front.

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.25.1
 
 require (
 	github.com/cli/browser v1.3.0
-	github.com/dash0hq/dash0-api-client-go v1.18.1
+	github.com/dash0hq/dash0-api-client-go v1.20.0
 	github.com/google/uuid v1.6.0
 	github.com/muesli/termenv v0.16.0
 	github.com/pmezard/go-difflib v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -11,8 +11,8 @@ github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XL
 github.com/cli/browser v1.3.0 h1:LejqCrpWr+1pRqmEPDGnTZOjsMe7sehifLynZJuqJpo=
 github.com/cli/browser v1.3.0/go.mod h1:HH8s+fOAxjhQoBUAsKuPCbqUuxZDhQ2/aD+SzsEfBTk=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
-github.com/dash0hq/dash0-api-client-go v1.18.1 h1:NhIt93aEj6C0YmVIWODESDbUbUTVwJ0JEFmC7qi54kw=
-github.com/dash0hq/dash0-api-client-go v1.18.1/go.mod h1:KNGbcgETrEN4m2QPGAorZ9FybTpVg/oi20UEoWGCGlE=
+github.com/dash0hq/dash0-api-client-go v1.20.0 h1:u0rLjG+Su8qTZvwLu8df+E2QvwXGC83GGihJ8fam+SA=
+github.com/dash0hq/dash0-api-client-go v1.20.0/go.mod h1:KNGbcgETrEN4m2QPGAorZ9FybTpVg/oi20UEoWGCGlE=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/internal/asset/prometheusrule_test.go
+++ b/internal/asset/prometheusrule_test.go
@@ -71,3 +71,125 @@ expression: up == 0
 	require.Len(t, rules, 1)
 	assert.Equal(t, "High Error Rate", rules[0].Name)
 }
+
+// The CRD below is trimmed to only what the assertions below exercise:
+// annotation merge and override. It omits labels, `for`, and PromQL detail
+// that no assertion touches.
+func TestParseCheckRules_TopLevelAnnotationsMergeIntoRules(t *testing.T) {
+	crd := []byte(`apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: checkout-check-rules
+  namespace: monitoring
+  annotations:
+    dash0.com/notification-channel-ids: "3fa42d0c-6b8e-4c1a-9f2d-111111111111,3fa42d0c-6b8e-4c1a-9f2d-222222222222"
+spec:
+  groups:
+    - name: Alerting
+      interval: 1m
+      rules:
+        - alert: CheckoutHighLatency
+          expr: up == 0
+        - alert: CheckoutHighErrorRate
+          expr: up == 0
+          annotations:
+            summary: "Checkout error rate is elevated"
+            dash0.com/notification-channel-ids: "3fa42d0c-6b8e-4c1a-9f2d-333333333333"
+            runbook_url: "https://runbooks.example.com/checkout-error-rate"
+`)
+
+	rules, err := ParseCheckRules(crd)
+	require.NoError(t, err)
+	require.Len(t, rules, 2)
+
+	// Rule 1 declared no annotations of its own, so it must inherit the
+	// top-level dash0.com/notification-channel-ids value verbatim.
+	latencyRule := rules[0]
+	require.NotNil(t, latencyRule.Annotations)
+	require.NotNil(t, latencyRule.Annotations.AdditionalProperties)
+	assert.Equal(t,
+		"3fa42d0c-6b8e-4c1a-9f2d-111111111111,3fa42d0c-6b8e-4c1a-9f2d-222222222222",
+		latencyRule.Annotations.AdditionalProperties["dash0.com/notification-channel-ids"],
+	)
+
+	// Rule 2's own dash0.com/notification-channel-ids overrides the
+	// top-level value (rule-level wins on conflict) and its unique
+	// runbook_url annotation is preserved.
+	errorRateRule := rules[1]
+	require.NotNil(t, errorRateRule.Annotations)
+	require.NotNil(t, errorRateRule.Annotations.AdditionalProperties)
+	assert.Equal(t,
+		"3fa42d0c-6b8e-4c1a-9f2d-333333333333",
+		errorRateRule.Annotations.AdditionalProperties["dash0.com/notification-channel-ids"],
+	)
+	assert.Equal(t,
+		"https://runbooks.example.com/checkout-error-rate",
+		errorRateRule.Annotations.AdditionalProperties["runbook_url"],
+	)
+	// The rule's own value must win outright, not be appended alongside the
+	// top-level one: assert the map has exactly the two additional keys
+	// expected (notification-channel-ids, runbook_url); summary is extracted
+	// onto its own dedicated struct field instead, asserted below.
+	assert.Len(t, errorRateRule.Annotations.AdditionalProperties, 2)
+	require.NotNil(t, errorRateRule.Annotations.Summary)
+	assert.Equal(t, "Checkout error rate is elevated", *errorRateRule.Annotations.Summary)
+}
+
+// The critical and degraded thresholds are two independent annotations, so a
+// document may set one at the top level and the other on the rule. They do not
+// collide on a key, and the merge is per key rather than a map replacement, so
+// both must survive onto the same check rule. A rule that restates a threshold
+// still wins for that threshold alone.
+func TestParseCheckRules_ThresholdsMergeFromBothLevels(t *testing.T) {
+	crd := []byte(`apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: checkout-thresholds
+  annotations:
+    dash0-threshold-critical: "1000"
+spec:
+  groups:
+    - name: Alerting
+      rules:
+        - alert: InheritsCriticalOnly
+          expr: up > $__threshold
+        - alert: AddsDegradedToInheritedCritical
+          expr: up > $__threshold
+          annotations:
+            dash0-threshold-degraded: "500"
+        - alert: OverridesBothThresholds
+          expr: up > $__threshold
+          annotations:
+            dash0-threshold-critical: "42"
+            dash0-threshold-degraded: "7"
+`)
+
+	rules, err := ParseCheckRules(crd)
+	require.NoError(t, err)
+	require.Len(t, rules, 3)
+
+	// Declaring no annotations, this rule inherits the top-level critical
+	// threshold and has no degraded threshold at all.
+	inherited := rules[0]
+	require.NotNil(t, inherited.Thresholds)
+	require.NotNil(t, inherited.Thresholds.Failed)
+	assert.Equal(t, float64(1000), *inherited.Thresholds.Failed)
+	assert.Nil(t, inherited.Thresholds.Degraded)
+
+	// The rule sets only the degraded threshold. Setting it must not discard
+	// the critical threshold coming from the top level: both apply.
+	split := rules[1]
+	require.NotNil(t, split.Thresholds)
+	require.NotNil(t, split.Thresholds.Failed)
+	require.NotNil(t, split.Thresholds.Degraded)
+	assert.Equal(t, float64(1000), *split.Thresholds.Failed)
+	assert.Equal(t, float64(500), *split.Thresholds.Degraded)
+
+	// The rule restates the critical threshold, so its own value wins.
+	overridden := rules[2]
+	require.NotNil(t, overridden.Thresholds)
+	require.NotNil(t, overridden.Thresholds.Failed)
+	require.NotNil(t, overridden.Thresholds.Degraded)
+	assert.Equal(t, float64(42), *overridden.Thresholds.Failed)
+	assert.Equal(t, float64(7), *overridden.Thresholds.Degraded)
+}

--- a/internal/checkrules/create_integration_test.go
+++ b/internal/checkrules/create_integration_test.go
@@ -1,0 +1,75 @@
+//go:build integration
+
+package checkrules
+
+import (
+	"net/http"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/dash0hq/dash0-cli/internal/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Exercises the fix through the full `check-rules create` command path
+// (parse -> import -> API call), not just the parsing helper covered by
+// TestParseCheckRules_TopLevelAnnotationsMergeIntoRules.
+func TestCreateCheckRule_PrometheusRuleCRD_TopLevelAnnotationsMerge(t *testing.T) {
+	testutil.SetupTestEnv(t)
+
+	server := testutil.NewMockServer(t, testutil.FixturesDir())
+	server.On(http.MethodPost, apiPathCheckRules, testutil.MockResponse{
+		StatusCode: http.StatusCreated,
+		BodyFile:   fixtureGetSuccess,
+		Validator:  testutil.RequireHeaders,
+	})
+
+	tmpDir := t.TempDir()
+	yamlFile := filepath.Join(tmpDir, "rules.yaml")
+	require.NoError(t, os.WriteFile(yamlFile, []byte(`apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: checkout-check-rules
+  namespace: monitoring
+  annotations:
+    dash0.com/notification-channel-ids: "3fa42d0c-6b8e-4c1a-9f2d-111111111111"
+spec:
+  groups:
+    - name: Alerting
+      interval: 1m
+      rules:
+        - alert: CheckoutHighLatency
+          expr: up == 0
+        - alert: CheckoutHighErrorRate
+          expr: up == 0
+          annotations:
+            dash0.com/notification-channel-ids: "3fa42d0c-6b8e-4c1a-9f2d-333333333333"
+            runbook_url: "https://runbooks.example.com/checkout-error-rate"
+`), 0644))
+
+	cmd := NewCheckRulesCmd()
+	cmd.SetArgs([]string{"create", "-f", yamlFile, "--api-url", server.URL, "--auth-token", testAuthToken})
+
+	require.NoError(t, cmd.Execute())
+
+	posts := server.RequestBodies(t, http.MethodPost, apiPathCheckRules)
+	require.Len(t, posts, 2)
+
+	bodiesByName := make(map[string]map[string]any, len(posts))
+	for _, body := range posts {
+		name, ok := body["name"].(string)
+		require.True(t, ok, "check rule body missing a string name: %v", body)
+		bodiesByName[name] = body
+	}
+
+	latencyAnnotations, ok := bodiesByName["Alerting - CheckoutHighLatency"]["annotations"].(map[string]any)
+	require.True(t, ok, "latency rule has no annotations; the rule must inherit the top-level metadata.annotations entry")
+	assert.Equal(t, "3fa42d0c-6b8e-4c1a-9f2d-111111111111", latencyAnnotations["dash0.com/notification-channel-ids"])
+
+	errorRateAnnotations, ok := bodiesByName["Alerting - CheckoutHighErrorRate"]["annotations"].(map[string]any)
+	require.True(t, ok, "error-rate rule has no annotations; it declares its own dash0.com/notification-channel-ids and runbook_url")
+	assert.Equal(t, "3fa42d0c-6b8e-4c1a-9f2d-333333333333", errorRateAnnotations["dash0.com/notification-channel-ids"])
+	assert.Equal(t, "https://runbooks.example.com/checkout-error-rate", errorRateAnnotations["runbook_url"])
+}

--- a/internal/skill/content/references/apply.md
+++ b/internal/skill/content/references/apply.md
@@ -28,7 +28,7 @@ For `Dash0SpamFilter`, the `apiVersion` field on the document selects the schema
 An unknown value fails validation up front, before any document is applied.
 
 For `PrometheusRule`, `apply` inspects each rule entry and dispatches by type.
-Alerting rules (entries with `alert:`) are sent to the check-rule endpoint as one check rule per alert, named `<group name> - <alert name>` to match the Dash0 Kubernetes operator and the Terraform provider.
+Alerting rules (entries with `alert:`) are sent to the check-rule endpoint as one check rule per alert, named `<group name> - <alert name>` to match the Dash0 Kubernetes operator and the Terraform provider (see [PrometheusRule annotation merge](#prometheusrule-annotation-merge)).
 Recording rules (entries with `record:`) are sent to the recording-rule endpoint as a single PrometheusRule CRD with the alerting rules removed.
 A CRD that mixes both kinds is dispatched to both endpoints in a single apply.
 A CRD that contains no alerting and no recording rules fails validation up front.
@@ -83,3 +83,128 @@ $ dash0 apply -f assets.yaml --dry-run
 Dry run: 1 document validated
   1. Dashboard "Production Overview" (a1b2c3d4-5678-90ab-cdef-1234567890ab)
 ```
+
+### PrometheusRule annotation merge
+
+A PrometheusRule document's top-level `metadata.annotations` are merged into each alerting rule's own annotations, key by key. A rule that sets the same key wins for that key only, and still inherits the rest.
+Use this to define a common setting once instead of repeating it on every rule in a multi-rule CRD.
+The recurring example is `dash0.com/notification-channel-ids`, whose value is a comma-separated list of notification channel ids (`dash0 notification-channels list` prints the available ids).
+This applies to `check-rules create`, `apply`, and `check-rules update`, though `update` operates on a single check rule and rejects a CRD containing more than one.
+
+Below, `CheckoutHighLatency` inherits the top-level channel and `CheckoutHighErrorRate` replaces it with its own:
+
+```yaml
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: checkout-alerts
+  annotations:
+    dash0.com/notification-channel-ids: ded5721c-2bf0-4a10-ab33-511fef734b0f
+spec:
+  groups:
+    - name: Alerting
+      rules:
+        - alert: CheckoutHighLatency
+          expr: histogram_quantile(0.99, sum by (le) (rate(http_server_request_duration_seconds_bucket{service_name="checkout"}[5m]))) > 1
+        - alert: CheckoutHighErrorRate
+          expr: sum(rate(http_server_request_duration_seconds_count{service_name="checkout", http_response_status_code=~"5.."}[5m])) > 0.1
+          annotations:
+            dash0.com/notification-channel-ids: 56aaacb2-10c6-4cef-8aeb-d7c862ad863e
+```
+
+```bash
+$ dash0 check-rules create -f checkout-alerts.yaml
+Check rule "Alerting - CheckoutHighLatency" created
+Check rule "Alerting - CheckoutHighErrorRate" created
+```
+
+`CheckoutHighLatency` declared no annotations of its own and still carries the top-level channel:
+
+```bash
+$ dash0 check-rules get a1b2c3d4-5678-90ab-cdef-1234567890ab -o yaml
+annotations:
+  dash0.com/notification-channel-ids: ded5721c-2bf0-4a10-ab33-511fef734b0f
+enabled: true
+expression: histogram_quantile(0.99, sum by (le) (rate(http_server_request_duration_seconds_bucket{service_name="checkout"}[5m])))
+  > 1
+id: a1b2c3d4-5678-90ab-cdef-1234567890ab
+name: Alerting - CheckoutHighLatency
+...
+```
+
+#### Annotations that control rule behavior
+
+A few annotations configure how a rule evaluates rather than describing it:
+
+| Annotation | Controls | Also accepted |
+|---|---|---|
+| `dash0-enabled` | whether the rule evaluates at all | |
+| `dash0-threshold-critical` | the critical threshold | `threshold-critical` |
+| `dash0-threshold-degraded` | the degraded threshold | `threshold-degraded` |
+
+These are unprefixed, unlike the `dash0.com/`-prefixed annotations above, so they are easy to mistake for ordinary metadata.
+They inherit and override like any other annotation, so a value set at the top level reaches every rule that does not name its own.
+Setting `dash0-enabled: "false"` there stops all of those rules from firing:
+
+```yaml
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: checkout-defaults
+  annotations:
+    dash0-enabled: "false"
+    dash0-threshold-critical: "5"
+spec:
+  groups:
+    - name: Alerting
+      rules:
+        - alert: InheritsDisabled
+          expr: up == 0
+        - alert: OverridesToEnabled
+          expr: up == 1
+          annotations:
+            dash0-enabled: "true"
+            dash0-threshold-critical: "9"
+```
+
+The critical and degraded thresholds are two separate annotations, so a document can set one at the top level and a rule can set the other.
+Both then apply to that rule.
+Below, the rule inherits a critical threshold of 1000 milliseconds and sets a degraded threshold of 500 milliseconds:
+
+```yaml
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: checkout-latency
+  annotations:
+    dash0-threshold-critical: "1000"
+spec:
+  groups:
+    - name: Alerting
+      rules:
+        - alert: Checkout P99 Latency
+          expr: histogram_quantile(0.99, sum by (le) (rate(http_server_request_duration_seconds_bucket{service_name="checkout"}[5m]))) * 1000 > $__threshold
+          annotations:
+            dash0-threshold-degraded: "500"
+```
+
+```bash
+$ dash0 check-rules get c3d4e5f6-7890-12cd-ef01-345678901bcd -o yaml
+id: c3d4e5f6-7890-12cd-ef01-345678901bcd
+name: Alerting - Checkout P99 Latency
+...
+thresholds:
+  degraded: 500
+  failed: 1000
+```
+
+The check then reports critical above 1000 milliseconds, degraded between 500 and 1000 milliseconds, and healthy below 500 milliseconds.
+A measurement that crosses both thresholds is reported as critical, never as both.
+
+Dash0 evaluates the critical threshold first, so the critical value has to be the more severe one for the comparison used in the expression: the higher number for `>`, the lower number for `<`.
+Swapping them in the rule above, to a critical threshold of 500 and a degraded threshold of 1000, reports critical from 500 milliseconds upwards and never reports degraded at all.
+
+The prefixed and unprefixed spellings of a setting are different annotation keys, and the prefixed one wins wherever both are present.
+That takes precedence over the rule-beats-document behavior above: a rule setting `threshold-critical` does not override a top-level `dash0-threshold-critical`.
+The losing value is not discarded either, it stays on the check rule as an ordinary annotation, which is usually how you notice.
+Use one spelling throughout a document.

--- a/internal/skill/content/references/check-rules.md
+++ b/internal/skill/content/references/check-rules.md
@@ -15,6 +15,131 @@
 | Spam filters | `dash0 spam-filters <subcommand>` | Dataset-scoped; `create`/`update` accept v1alpha1 (`spec.contexts`) and v1alpha2 (`spec.context`) |
 | Teams | `dash0 --experimental teams <subcommand>` | Organization-level (no `--dataset`). Experimental. `create` accepts `-f <file>` for a declarative `TeamDefinitionV1Alpha1` document, or a positional `<name>` for the imperative form. `spec.members` and `--member` accept either an email address or an internal member id; the server resolves emails. |
 
+### PrometheusRule annotation merge
+
+A PrometheusRule document's top-level `metadata.annotations` are merged into each alerting rule's own annotations, key by key. A rule that sets the same key wins for that key only, and still inherits the rest.
+Use this to define a common setting once instead of repeating it on every rule in a multi-rule CRD.
+The recurring example is `dash0.com/notification-channel-ids`, whose value is a comma-separated list of notification channel ids (`dash0 notification-channels list` prints the available ids).
+This applies to `check-rules create`, `apply`, and `check-rules update`, though `update` operates on a single check rule and rejects a CRD containing more than one.
+
+Below, `CheckoutHighLatency` inherits the top-level channel and `CheckoutHighErrorRate` replaces it with its own:
+
+```yaml
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: checkout-alerts
+  annotations:
+    dash0.com/notification-channel-ids: ded5721c-2bf0-4a10-ab33-511fef734b0f
+spec:
+  groups:
+    - name: Alerting
+      rules:
+        - alert: CheckoutHighLatency
+          expr: histogram_quantile(0.99, sum by (le) (rate(http_server_request_duration_seconds_bucket{service_name="checkout"}[5m]))) > 1
+        - alert: CheckoutHighErrorRate
+          expr: sum(rate(http_server_request_duration_seconds_count{service_name="checkout", http_response_status_code=~"5.."}[5m])) > 0.1
+          annotations:
+            dash0.com/notification-channel-ids: 56aaacb2-10c6-4cef-8aeb-d7c862ad863e
+```
+
+```bash
+$ dash0 check-rules create -f checkout-alerts.yaml
+Check rule "Alerting - CheckoutHighLatency" created
+Check rule "Alerting - CheckoutHighErrorRate" created
+```
+
+`CheckoutHighLatency` declared no annotations of its own and still carries the top-level channel:
+
+```bash
+$ dash0 check-rules get a1b2c3d4-5678-90ab-cdef-1234567890ab -o yaml
+annotations:
+  dash0.com/notification-channel-ids: ded5721c-2bf0-4a10-ab33-511fef734b0f
+enabled: true
+expression: histogram_quantile(0.99, sum by (le) (rate(http_server_request_duration_seconds_bucket{service_name="checkout"}[5m])))
+  > 1
+id: a1b2c3d4-5678-90ab-cdef-1234567890ab
+name: Alerting - CheckoutHighLatency
+...
+```
+
+#### Annotations that control rule behavior
+
+A few annotations configure how a rule evaluates rather than describing it:
+
+| Annotation | Controls | Also accepted |
+|---|---|---|
+| `dash0-enabled` | whether the rule evaluates at all | |
+| `dash0-threshold-critical` | the critical threshold | `threshold-critical` |
+| `dash0-threshold-degraded` | the degraded threshold | `threshold-degraded` |
+
+These are unprefixed, unlike the `dash0.com/`-prefixed annotations above, so they are easy to mistake for ordinary metadata.
+They inherit and override like any other annotation, so a value set at the top level reaches every rule that does not name its own.
+Setting `dash0-enabled: "false"` there stops all of those rules from firing:
+
+```yaml
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: checkout-defaults
+  annotations:
+    dash0-enabled: "false"
+    dash0-threshold-critical: "5"
+spec:
+  groups:
+    - name: Alerting
+      rules:
+        - alert: InheritsDisabled
+          expr: up == 0
+        - alert: OverridesToEnabled
+          expr: up == 1
+          annotations:
+            dash0-enabled: "true"
+            dash0-threshold-critical: "9"
+```
+
+The critical and degraded thresholds are two separate annotations, so a document can set one at the top level and a rule can set the other.
+Both then apply to that rule.
+Below, the rule inherits a critical threshold of 1000 milliseconds and sets a degraded threshold of 500 milliseconds:
+
+```yaml
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: checkout-latency
+  annotations:
+    dash0-threshold-critical: "1000"
+spec:
+  groups:
+    - name: Alerting
+      rules:
+        - alert: Checkout P99 Latency
+          expr: histogram_quantile(0.99, sum by (le) (rate(http_server_request_duration_seconds_bucket{service_name="checkout"}[5m]))) * 1000 > $__threshold
+          annotations:
+            dash0-threshold-degraded: "500"
+```
+
+```bash
+$ dash0 check-rules get c3d4e5f6-7890-12cd-ef01-345678901bcd -o yaml
+id: c3d4e5f6-7890-12cd-ef01-345678901bcd
+name: Alerting - Checkout P99 Latency
+...
+thresholds:
+  degraded: 500
+  failed: 1000
+```
+
+The check then reports critical above 1000 milliseconds, degraded between 500 and 1000 milliseconds, and healthy below 500 milliseconds.
+A measurement that crosses both thresholds is reported as critical, never as both.
+
+Dash0 evaluates the critical threshold first, so the critical value has to be the more severe one for the comparison used in the expression: the higher number for `>`, the lower number for `<`.
+Swapping them in the rule above, to a critical threshold of 500 and a degraded threshold of 1000, reports critical from 500 milliseconds upwards and never reports degraded at all.
+
+The prefixed and unprefixed spellings of a setting are different annotation keys, and the prefixed one wins wherever both are present.
+That takes precedence over the rule-beats-document behavior above: a rule setting `threshold-critical` does not override a top-level `dash0-threshold-critical`.
+The losing value is not discarded either, it stays on the check rule as an ordinary annotation, which is usually how you notice.
+Use one spelling throughout a document.
+
 Check rule:
 
 ```yaml
@@ -25,4 +150,4 @@ name: High Error Rate
 expression: sum(rate(http_requests_total{status=~"5.."}[5m])) > 0.1
 ```
 
-`check-rules create` also accepts PrometheusRule CRD files. Each alerting rule in the CRD is created as a separate check rule (recording rules are skipped), named `<group name> - <alert name>`, matching the Dash0 Kubernetes operator and the Terraform provider. See the `recording-rules` topic for the recording-rule half of a mixed PrometheusRule CRD.
+`check-rules create` also accepts PrometheusRule CRD files. Each alerting rule in the CRD is created as a separate check rule (recording rules are skipped), named `<group name> - <alert name>`, matching the Dash0 Kubernetes operator and the Terraform provider. The CRD's top-level `metadata.annotations` are merged into every rule it contains (see [PrometheusRule annotation merge](#prometheusrule-annotation-merge)). See the `recording-rules` topic for the recording-rule half of a mixed PrometheusRule CRD.

--- a/internal/skill/gen/main.go
+++ b/internal/skill/gen/main.go
@@ -50,16 +50,19 @@ type topicSpec struct {
 }
 
 var topics = []topicSpec{
-	{name: "apply", sections: []string{"apply"}},
+	{name: "apply", sections: []string{"apply", "prometheusrule annotation merge"}},
 	{name: "api", sections: []string{"api"}},
 	{
 		name:            "check-rules",
 		includeQuickRef: true,
+		sections:        []string{"prometheusrule annotation merge"},
 		assetYAMLLabels: []string{"Check rule:"},
 		extraNote: "`check-rules create` also accepts PrometheusRule CRD files. Each alerting rule in the CRD " +
 			"is created as a separate check rule (recording rules are skipped), named `<group name> - <alert name>`, " +
-			"matching the Dash0 Kubernetes operator and the Terraform provider. See the `recording-rules` topic for " +
-			"the recording-rule half of a mixed PrometheusRule CRD.",
+			"matching the Dash0 Kubernetes operator and the Terraform provider. The CRD's top-level " +
+			"`metadata.annotations` are merged into every rule it contains (see " +
+			"[PrometheusRule annotation merge](#prometheusrule-annotation-merge)). See the `recording-rules` topic " +
+			"for the recording-rule half of a mixed PrometheusRule CRD.",
 	},
 	{
 		name: "config",
@@ -135,7 +138,7 @@ var topics = []topicSpec{
 type heading struct {
 	level int
 	title string // raw title text, as written after the leading #'s
-	start int     // line index of the heading line itself
+	start int    // line index of the heading line itself
 }
 
 func main() {

--- a/internal/testutil/mockserver.go
+++ b/internal/testutil/mockserver.go
@@ -15,6 +15,8 @@ import (
 	"strings"
 	"sync"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 // Fixture paths relative to the fixtures directory.
@@ -243,6 +245,24 @@ func (m *MockServer) LastRequest() *RecordedRequest {
 	}
 	req := m.requests[len(m.requests)-1]
 	return &req
+}
+
+// RequestBodies returns the decoded JSON bodies of all recorded requests
+// matching method and path, in the order they were received. Use this
+// instead of LastRequest when a command issues more than one request to the
+// same route and the test needs to inspect all of them, not just the last.
+func (m *MockServer) RequestBodies(t *testing.T, method, path string) []map[string]any {
+	t.Helper()
+	var bodies []map[string]any
+	for _, req := range m.Requests() {
+		if req.Method != method || req.Path != path {
+			continue
+		}
+		var body map[string]any
+		require.NoError(t, json.Unmarshal(req.Body, &body))
+		bodies = append(bodies, body)
+	}
+	return bodies
 }
 
 // Reset clears all recorded requests.

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -43,7 +43,7 @@ buildGoModule (finalAttrs: {
   # replaced with the real hash: build once, then copy the `got: sha256-...`
   # value from the resulting hash-mismatch error into this field. Re-run after
   # any change to go.mod / go.sum. See the README's "Install with Nix" section.
-  vendorHash = "sha256-7p3uYQSwgRdMnXSZICHHDY6lR/171YJPSnx0w9e27Kk=";
+  vendorHash = "sha256-GJzLrYvUMVPK/PfLtDTKnMti/96S5J2XVMUk06cdMQo=";
 
   # Only the CLI entrypoint is a `main` package; building it explicitly avoids
   # compiling test-only helpers into the output.


### PR DESCRIPTION
Closes #245.

`check-rules create`/`apply` parses PrometheusRule CRD YAML through `dash0-api-client-go`'s `ParseAsPrometheusAlertRules`. That function used to drop a document's top-level `metadata.annotations`. Fixed upstream in dash0-api-client-go#29 (released as v1.19.1).

## What this adds

A regression test proving the merge reaches the CLI: an integration test asserting the merge shows up in the actual request body sent by `check-rules create`. Also a documentation note in `docs/commands.md` and the skill bundle.

An earlier version of this PR also covered a second gap (rejecting a `$__threshold` rule with no threshold annotation). That half was pulled from the upstream fix per review, dash0-api-client-go#29 conflicts with in-flight design work on structured threshold values, so the corresponding CLI-side tests and doc sentences were removed here too.

## How to review

`internal/checkrules/create_integration_test.go` is the test that matters, it shows the exact request body a user's apply would produce. Everything else here is documentation.

## Test plan

- [x] Now depends on the released `dash0-api-client-go` v1.19.1 (`go.mod`/`go.sum` bumped, local replace removed)
- [x] `make build`, `make test-unit`, `make test-integration` — all pass against the real dependency
- [x] `make lint-go` — clean
- [x] `make skill-validate` — clean