### PR TITLE
fix(oauth): send client_id on token revocation

### DIFF
--- a/.chloggen/oauth-revocation-includes-client-id.yaml
+++ b/.chloggen/oauth-revocation-includes-client-id.yaml
@@ -1,0 +1,29 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern (e.g. dashboards, config, apply)
+component: login
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Send `client_id` on OAuth token revocation requests"
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [249]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  `dash0 logout`, `dash0 login` (on re-login), and `dash0 config profiles update --oauth=false` now
+  include the profile's client_id when revoking a refresh token, matching the authorization server's
+  requirement. Without it, revocation silently failed and the old refresh token stayed valid.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with "chore" or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Default: '[user]'
+change_logs: []

--- a/go.mod
+++ b/go.mod
@@ -138,8 +138,3 @@ require (
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260803160001-6ac0973c030d // indirect
 	google.golang.org/protobuf v1.36.12 // indirect
 )
-
-// Temporary local redirect so this branch can consume ClientId on
-// OAuthRevocationRequest from dash0-api-client-go#31 before that PR is
-// released. Drop this replace and bump the require once the client ships.
-replace github.com/dash0hq/dash0-api-client-go => ../dash0-api-client-go

--- a/go.mod
+++ b/go.mod
@@ -138,3 +138,8 @@ require (
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260803160001-6ac0973c030d // indirect
 	google.golang.org/protobuf v1.36.12 // indirect
 )
+
+// Temporary local redirect so this branch can consume ClientId on
+// OAuthRevocationRequest from dash0-api-client-go#31 before that PR is
+// released. Drop this replace and bump the require once the client ships.
+replace github.com/dash0hq/dash0-api-client-go => ../dash0-api-client-go

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"os"
 	"strings"
@@ -608,6 +609,73 @@ func TestCheckOAuthOnOtlp_AgentModeMessage(t *testing.T) {
 	err := checkOAuthOnOtlp(context.Background(), cfg, cfg.AuthToken)
 	if err == nil {
 		t.Fatalf("expected an error in agent mode, got nil")
+	}
+	if strings.Contains(err.Error(), "dash0 login") {
+		t.Errorf("agent-mode error must not point at `dash0 login`: %q", err.Error())
+	}
+	if !strings.Contains(err.Error(), "DASH0_AUTH_TOKEN") {
+		t.Errorf("agent-mode error must surface DASH0_AUTH_TOKEN: %q", err.Error())
+	}
+	if !strings.Contains(err.Error(), "--oauth=false") {
+		t.Errorf("agent-mode error must surface the profile conversion path: %q", err.Error())
+	}
+}
+
+// revokedRefreshTokenErrorBody is the exact response body observed from the
+// token endpoint when exchanging a refresh token that has already been
+// revoked (e.g. by a prior `dash0 logout`).
+const revokedRefreshTokenErrorBody = `{"error":"invalid_grant","error_description":"The refresh token has already been used. The entire token family has been revoked."}`
+
+// revokedRefreshTokenError decodes revokedRefreshTokenErrorBody the same way
+// the SDK's token-exchange path would, and wraps it the same way
+// NewClientFromContext's OAuth-refresh failure does, so the test starts
+// from the literal bytes the authorization server sends rather than a
+// hand-built struct.
+func revokedRefreshTokenError(t *testing.T) error {
+	t.Helper()
+	var parsed dash0api.OAuthTokenErrorResponse
+	require.NoError(t, json.Unmarshal([]byte(revokedRefreshTokenErrorBody), &parsed))
+	description := ""
+	if parsed.ErrorDescription != nil {
+		description = *parsed.ErrorDescription
+	}
+	oauthErr := &dash0api.OAuthTokenError{
+		StatusCode:  400,
+		Code:        parsed.Error,
+		Description: description,
+	}
+	return fmt.Errorf("failed to refresh OAuth access token: %w", oauthErr)
+}
+
+// TestTranslateConfigError_RevokedRefreshToken asserts that when the
+// authorization server rejects a refresh token as revoked, the CLI
+// surfaces the friendly re-login hint instead of leaking the wrapped SDK
+// error.
+func TestTranslateConfigError_RevokedRefreshToken(t *testing.T) {
+	err := translateConfigError(context.Background(), revokedRefreshTokenError(t))
+	if err == nil {
+		t.Fatalf("expected a translated error, got nil")
+	}
+	if !strings.Contains(err.Error(), "your Dash0 session has expired or was revoked") {
+		t.Errorf("error does not name the root cause: %q", err.Error())
+	}
+	if !strings.Contains(err.Error(), "dash0 login") {
+		t.Errorf("error does not point at `dash0 login`: %q", err.Error())
+	}
+}
+
+// TestTranslateConfigError_RevokedRefreshToken_AgentMode asserts the
+// agent-mode branch of the same translation drops the `dash0 login`
+// reference (login refuses to run without a TTY) in favor of the
+// DASH0_AUTH_TOKEN / --oauth=false escape hatches.
+func TestTranslateConfigError_RevokedRefreshToken_AgentMode(t *testing.T) {
+	prev := agentmode.Enabled
+	agentmode.Enabled = true
+	defer func() { agentmode.Enabled = prev }()
+
+	err := translateConfigError(context.Background(), revokedRefreshTokenError(t))
+	if err == nil {
+		t.Fatalf("expected a translated error, got nil")
 	}
 	if strings.Contains(err.Error(), "dash0 login") {
 		t.Errorf("agent-mode error must not point at `dash0 login`: %q", err.Error())

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -665,9 +665,9 @@ func TestTranslateConfigError_RevokedRefreshToken(t *testing.T) {
 }
 
 // TestTranslateConfigError_RevokedRefreshToken_AgentMode asserts the
-// agent-mode branch of the same translation drops the `dash0 login`
-// reference (login refuses to run without a TTY) in favor of the
-// DASH0_AUTH_TOKEN / --oauth=false escape hatches.
+// agent-mode branch of the same translation does not tell the caller to
+// run `dash0 login` (it may still explain that login is unavailable) and
+// instead surfaces the DASH0_AUTH_TOKEN / --oauth=false escape hatches.
 func TestTranslateConfigError_RevokedRefreshToken_AgentMode(t *testing.T) {
 	prev := agentmode.Enabled
 	agentmode.Enabled = true
@@ -677,8 +677,8 @@ func TestTranslateConfigError_RevokedRefreshToken_AgentMode(t *testing.T) {
 	if err == nil {
 		t.Fatalf("expected a translated error, got nil")
 	}
-	if strings.Contains(err.Error(), "dash0 login") {
-		t.Errorf("agent-mode error must not point at `dash0 login`: %q", err.Error())
+	if strings.Contains(err.Error(), "Run `dash0 login") {
+		t.Errorf("agent-mode error must not instruct the caller to run `dash0 login`: %q", err.Error())
 	}
 	if !strings.Contains(err.Error(), "DASH0_AUTH_TOKEN") {
 		t.Errorf("agent-mode error must surface DASH0_AUTH_TOKEN: %q", err.Error())

--- a/internal/config/config_cmd.go
+++ b/internal/config/config_cmd.go
@@ -528,8 +528,11 @@ are mutually exclusive.`,
 				// the token.
 				if existing.OAuth != nil {
 					if !oauthpkg.Revoke(oauthpkg.RevokeRequest{
-						APIURL:       existing.ApiUrl,
-						ClientID:     existing.OAuth.ClientID,
+						APIURL: existing.ApiUrl,
+						// Resolve a profile written without a stored
+						// ClientID through the DCR cache here, at read
+						// time; oauthpkg.Revoke uses the field verbatim.
+						ClientID:     profiles.ResolveOAuthClientID(existing.ApiUrl, existing.OAuth.ClientID),
 						RefreshToken: existing.OAuth.RefreshToken,
 					}) {
 						defer fmt.Println("Note: server-side refresh-token revocation failed; the token will remain valid on the authorization server until natural expiry.")

--- a/internal/config/config_cmd.go
+++ b/internal/config/config_cmd.go
@@ -527,7 +527,11 @@ are mutually exclusive.`,
 				// after the update so the user knows the AS still holds
 				// the token.
 				if existing.OAuth != nil {
-					if !oauthpkg.Revoke(existing.ApiUrl, existing.OAuth.ClientID, existing.OAuth.RefreshToken) {
+					if !oauthpkg.Revoke(oauthpkg.RevokeRequest{
+						APIURL:       existing.ApiUrl,
+						ClientID:     existing.OAuth.ClientID,
+						RefreshToken: existing.OAuth.RefreshToken,
+					}) {
 						defer fmt.Println("Note: server-side refresh-token revocation failed; the token will remain valid on the authorization server until natural expiry.")
 					}
 				}

--- a/internal/config/config_cmd.go
+++ b/internal/config/config_cmd.go
@@ -527,7 +527,7 @@ are mutually exclusive.`,
 				// after the update so the user knows the AS still holds
 				// the token.
 				if existing.OAuth != nil {
-					if !oauthpkg.Revoke(existing.ApiUrl, existing.OAuth.RefreshToken) {
+					if !oauthpkg.Revoke(existing.ApiUrl, existing.OAuth.ClientID, existing.OAuth.RefreshToken) {
 						defer fmt.Println("Note: server-side refresh-token revocation failed; the token will remain valid on the authorization server until natural expiry.")
 					}
 				}

--- a/internal/config/config_cmd_test.go
+++ b/internal/config/config_cmd_test.go
@@ -5,6 +5,9 @@ import (
 	"context"
 	"encoding/json"
 	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
 	"os"
 	"testing"
 
@@ -1212,5 +1215,68 @@ func TestUpdateProfileCmdAuthTokenOnOAuthActiveErrors(t *testing.T) {
 	}
 	if !bytes.Contains([]byte(err.Error()), []byte("--oauth=false")) {
 		t.Errorf("expected error to suggest --oauth=false, got: %v", err)
+	}
+}
+
+func TestUpdateProfileCmdOAuthFalseRevokesWithClientID(t *testing.T) {
+	_ = setupTestConfigDir(t)
+
+	var gotForm url.Values
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/oauth/revoke" {
+			t.Errorf("unexpected request to %s", r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		if err := r.ParseForm(); err != nil {
+			t.Fatalf("failed to parse revoke form: %v", err)
+		}
+		gotForm = r.Form
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	store, _ := profiles.NewStore()
+	if err := store.AddProfile(profiles.Profile{
+		Name: "oauth-active",
+		Configuration: profiles.Configuration{
+			ApiUrl:    server.URL,
+			AuthToken: "dash0_at_xxxxxxxxxxxx",
+			OAuth: &profiles.OAuthState{
+				ClientID:     "cli-client-id-abc",
+				RefreshToken: "dash0_rt_yyy",
+			},
+		},
+	}); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	rootCmd := &cobra.Command{Use: "dash0"}
+	rootCmd.AddCommand(NewConfigCmd())
+
+	if _, err := executeCommand(rootCmd, "config", "profiles", "update", "oauth-active",
+		"--oauth=false", "--auth-token", "auth_new_xxxxxx", "--force"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if gotForm == nil {
+		t.Fatalf("expected a revoke request to reach the server")
+	}
+	if got := gotForm.Get("client_id"); got != "cli-client-id-abc" {
+		t.Errorf("expected client_id %q on the revoke request, got %q", "cli-client-id-abc", got)
+	}
+	if got := gotForm.Get("token"); got != "dash0_rt_yyy" {
+		t.Errorf("expected token %q on the revoke request, got %q", "dash0_rt_yyy", got)
+	}
+
+	all, _ := store.GetProfiles()
+	if len(all) != 1 {
+		t.Fatalf("expected 1 profile, got %d", len(all))
+	}
+	if all[0].Configuration.AuthToken != "auth_new_xxxxxx" {
+		t.Errorf("expected new AuthToken to be set, got %q", all[0].Configuration.AuthToken)
+	}
+	if all[0].Configuration.OAuth != nil {
+		t.Errorf("expected OAuth block cleared after --oauth=false, got %+v", all[0].Configuration.OAuth)
 	}
 }

--- a/internal/config/config_cmd_test.go
+++ b/internal/config/config_cmd_test.go
@@ -1229,7 +1229,9 @@ func TestUpdateProfileCmdOAuthFalseRevokesWithClientID(t *testing.T) {
 			return
 		}
 		if err := r.ParseForm(); err != nil {
-			t.Fatalf("failed to parse revoke form: %v", err)
+			t.Errorf("failed to parse revoke form: %v", err)
+			w.WriteHeader(http.StatusBadRequest)
+			return
 		}
 		gotForm = r.Form
 		w.WriteHeader(http.StatusOK)

--- a/internal/login/integration_test.go
+++ b/internal/login/integration_test.go
@@ -212,11 +212,14 @@ func (f *fakeOAuthServer) handleToken(w http.ResponseWriter, r *http.Request) {
 }
 
 func (f *fakeOAuthServer) handleRevoke(w http.ResponseWriter, r *http.Request) {
-	require.NoError(f.t, r.ParseForm())
+	if !assert.NoError(f.t, r.ParseForm()) {
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
 	token := r.Form.Get("token")
-	require.NotEmpty(f.t, token, "revoke requires a token")
+	assert.NotEmpty(f.t, token, "revoke requires a token")
 	clientID := r.Form.Get("client_id")
-	require.NotEmpty(f.t, clientID, "revoke requires a client_id")
+	assert.NotEmpty(f.t, clientID, "revoke requires a client_id")
 	f.revokeCount.Add(1)
 	f.revoked.Lock()
 	f.revokedList = append(f.revokedList, token)

--- a/internal/login/integration_test.go
+++ b/internal/login/integration_test.go
@@ -52,6 +52,12 @@ type fakeOAuthServer struct {
 	tokenErrorCode     atomic.Value // string -- 400 with this OAuth error code
 	tokenOmitRefresh   atomic.Bool  // 200 OK with access_token but no refresh_token
 	tokenExpiresIn     atomic.Int64 // when > 0, overrides the 3600s default expires_in
+
+	// revokeAllowMissingClientID stops handleRevoke from failing the test
+	// when a revoke arrives without a client_id. The handler still answers
+	// 400, the way a real AS does; only the assertion is lifted, for the
+	// one test whose point is that no client_id goes out.
+	revokeAllowMissingClientID atomic.Bool
 }
 
 func newFakeOAuthServer(t *testing.T) *fakeOAuthServer {
@@ -219,7 +225,12 @@ func (f *fakeOAuthServer) handleRevoke(w http.ResponseWriter, r *http.Request) {
 	token := r.Form.Get("token")
 	assert.NotEmpty(f.t, token, "revoke requires a token")
 	clientID := r.Form.Get("client_id")
-	assert.NotEmpty(f.t, clientID, "revoke requires a client_id")
+	if !f.revokeAllowMissingClientID.Load() {
+		assert.NotEmpty(f.t, clientID, "revoke requires a client_id")
+	}
+
+	// Record the attempt before answering, so a test can assert on what
+	// went out even when the request is the one being rejected.
 	f.revokeCount.Add(1)
 	f.revoked.Lock()
 	f.revokedList = append(f.revokedList, token)
@@ -228,6 +239,17 @@ func (f *fakeOAuthServer) handleRevoke(w http.ResponseWriter, r *http.Request) {
 	}
 	f.revokedClientIDs[token] = clientID
 	f.revoked.Unlock()
+
+	// RFC 7009 §2.1 makes client_id mandatory for a public client, and the
+	// Dash0 AS enforces it. Answering 200 to a request this server itself
+	// just called malformed would hand any future assertion on the status,
+	// or on runLogin's error, a success signal.
+	if clientID == "" {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		_ = json.NewEncoder(w).Encode(map[string]any{"error": "invalid_client"})
+		return
+	}
 	w.WriteHeader(http.StatusOK)
 }
 
@@ -452,6 +474,53 @@ func TestRunLogin_OnOAuthActive_RevokesOldRefreshWithOldClientID(t *testing.T) {
 		"the old refresh token must be revoked using the client_id that issued it, not the freshly-registered one")
 }
 
+func TestRunLogin_OnOAuthActiveWithoutStoredClientID_DoesNotRevokeWithFreshClientID(t *testing.T) {
+	forceInteractive(t)
+	t.Setenv("DASH0_CONFIG_DIR", t.TempDir())
+
+	server := newFakeOAuthServer(t)
+	defer server.Close()
+	server.clientID = "client-freshly-registered"
+	// A profile with no stored ClientID is the case under test, so the
+	// missing client_id on the wire is the expected outcome, not a failure.
+	server.revokeAllowMissingClientID.Store(true)
+
+	store, _ := profiles.NewStore()
+	require.NoError(t, store.AddProfile(profiles.Profile{
+		Name: "active-prof",
+		Configuration: profiles.Configuration{
+			ApiUrl:    server.URL(),
+			AuthToken: "dash0_at_old_xxxxxxxxxxxx",
+			OAuth: &profiles.OAuthState{
+				// Hand-edited, or written by other SDK tooling: OAuth
+				// state with a refresh token but no client ID.
+				ClientID:     "",
+				RefreshToken: "dash0_rt_OLD_to_be_revoked",
+				ExpiresAt:    time.Now().Add(time.Hour),
+			},
+		},
+	}))
+
+	defer driveBrowserOnce(t)()
+
+	err := runLogin(context.Background(), loginOptions{
+		ProfileName: "active-prof",
+		Timeout:     5 * time.Second,
+	})
+	// The revoke is best-effort: it fails honestly (the AS rejects a
+	// revoke with no client_id) and login still succeeds, printing a Note.
+	require.NoError(t, err)
+
+	revoked := server.Revoked()
+	require.Len(t, revoked, 1)
+	require.Equal(t, "dash0_rt_OLD_to_be_revoked", revoked[0])
+	require.NotEqual(t, "client-freshly-registered", server.RevokedClientID("dash0_rt_OLD_to_be_revoked"),
+		"the old refresh token must never be revoked under the client this login just registered; "+
+			"the DCR cache is keyed by API URL alone, so a fallback read after registration would send exactly that")
+	require.Empty(t, server.RevokedClientID("dash0_rt_OLD_to_be_revoked"),
+		"with no stored client ID resolvable before registration, the revoke must go out without a client_id and fail honestly")
+}
+
 func TestRunLogin_RejectsInAgentMode(t *testing.T) {
 	prev := isTerminal
 	isTerminal = func() bool { return false }
@@ -493,6 +562,44 @@ func TestRunLogout_OnOAuthActive_ClearsState(t *testing.T) {
 	require.Equal(t, "", all[0].Configuration.AuthToken)
 	require.NotNil(t, all[0].Configuration.OAuth)
 	require.Equal(t, "", all[0].Configuration.OAuth.RefreshToken)
+}
+
+// TestRunLogout_WithoutStoredClientID_ResolvesFromDCRCache covers the half
+// of the client-ID resolution that stays safe: logout registers no new
+// client, so the DCR cache entry for this API URL is still the one that
+// issued the token, and a profile written without a ClientID can be
+// revoked correctly.
+func TestRunLogout_WithoutStoredClientID_ResolvesFromDCRCache(t *testing.T) {
+	t.Setenv("DASH0_CONFIG_DIR", t.TempDir())
+
+	server := newFakeOAuthServer(t)
+	defer server.Close()
+
+	clientStore, err := profiles.NewOAuthClientStore()
+	require.NoError(t, err)
+	require.NoError(t, clientStore.Put(server.URL(), profiles.OAuthClientRecord{
+		ClientID:    "client-cached-from-dcr",
+		RedirectURI: "http://127.0.0.1/callback",
+	}))
+
+	store, _ := profiles.NewStore()
+	require.NoError(t, store.AddProfile(profiles.Profile{
+		Name: "oauth-prof",
+		Configuration: profiles.Configuration{
+			ApiUrl:    server.URL(),
+			AuthToken: "dash0_at_aaaaaaaaaaaaaa",
+			OAuth: &profiles.OAuthState{
+				ClientID:     "",
+				RefreshToken: "dash0_rt_to_revoke",
+				ExpiresAt:    time.Now().Add(time.Hour),
+			},
+		},
+	}))
+
+	require.NoError(t, runLogout(context.Background(), logoutOptions{Force: true}))
+
+	require.Equal(t, []string{"dash0_rt_to_revoke"}, server.Revoked())
+	require.Equal(t, "client-cached-from-dcr", server.RevokedClientID("dash0_rt_to_revoke"))
 }
 
 func TestRunLogout_OnOAuthEmpty_NoOp(t *testing.T) {

--- a/internal/login/integration_test.go
+++ b/internal/login/integration_test.go
@@ -34,11 +34,12 @@ type fakeOAuthServer struct {
 	server   *httptest.Server
 	clientID string
 
-	issuedCode      atomic.Value // string
-	issuedChallenge atomic.Value // string -- PKCE code_challenge stored on /authorize
-	revokeCount     atomic.Int32
-	revoked         sync.Mutex
-	revokedList     []string
+	issuedCode       atomic.Value // string
+	issuedChallenge  atomic.Value // string -- PKCE code_challenge stored on /authorize
+	revokeCount      atomic.Int32
+	revoked          sync.Mutex
+	revokedList      []string
+	revokedClientIDs map[string]string // token -> client_id
 
 	// tokenCounter lets us hand out distinct access/refresh tokens so the
 	// re-login test can prove the old refresh was revoked.
@@ -78,6 +79,12 @@ func (f *fakeOAuthServer) Revoked() []string {
 	out := make([]string, len(f.revokedList))
 	copy(out, f.revokedList)
 	return out
+}
+
+func (f *fakeOAuthServer) RevokedClientID(token string) string {
+	f.revoked.Lock()
+	defer f.revoked.Unlock()
+	return f.revokedClientIDs[token]
 }
 
 func (f *fakeOAuthServer) handleDiscovery(w http.ResponseWriter, _ *http.Request) {
@@ -208,9 +215,15 @@ func (f *fakeOAuthServer) handleRevoke(w http.ResponseWriter, r *http.Request) {
 	require.NoError(f.t, r.ParseForm())
 	token := r.Form.Get("token")
 	require.NotEmpty(f.t, token, "revoke requires a token")
+	clientID := r.Form.Get("client_id")
+	require.NotEmpty(f.t, clientID, "revoke requires a client_id")
 	f.revokeCount.Add(1)
 	f.revoked.Lock()
 	f.revokedList = append(f.revokedList, token)
+	if f.revokedClientIDs == nil {
+		f.revokedClientIDs = make(map[string]string)
+	}
+	f.revokedClientIDs[token] = clientID
 	f.revoked.Unlock()
 	w.WriteHeader(http.StatusOK)
 }
@@ -397,6 +410,43 @@ func TestRunLogin_OnOAuthActive_RevokesOldRefresh(t *testing.T) {
 	revoked := server.Revoked()
 	require.Len(t, revoked, 1)
 	require.Equal(t, "dash0_rt_OLD_to_be_revoked", revoked[0])
+}
+
+func TestRunLogin_OnOAuthActive_RevokesOldRefreshWithOldClientID(t *testing.T) {
+	forceInteractive(t)
+	t.Setenv("DASH0_CONFIG_DIR", t.TempDir())
+
+	server := newFakeOAuthServer(t)
+	defer server.Close()
+	server.clientID = "client-freshly-registered"
+
+	store, _ := profiles.NewStore()
+	require.NoError(t, store.AddProfile(profiles.Profile{
+		Name: "active-prof",
+		Configuration: profiles.Configuration{
+			ApiUrl:    server.URL(),
+			AuthToken: "dash0_at_old_xxxxxxxxxxxx",
+			OAuth: &profiles.OAuthState{
+				ClientID:     "client-that-issued-the-old-token",
+				RefreshToken: "dash0_rt_OLD_to_be_revoked",
+				ExpiresAt:    time.Now().Add(time.Hour),
+			},
+		},
+	}))
+
+	defer driveBrowserOnce(t)()
+
+	err := runLogin(context.Background(), loginOptions{
+		ProfileName: "active-prof",
+		Timeout:     5 * time.Second,
+	})
+	require.NoError(t, err)
+
+	revoked := server.Revoked()
+	require.Len(t, revoked, 1)
+	require.Equal(t, "dash0_rt_OLD_to_be_revoked", revoked[0])
+	require.Equal(t, "client-that-issued-the-old-token", server.RevokedClientID("dash0_rt_OLD_to_be_revoked"),
+		"the old refresh token must be revoked using the client_id that issued it, not the freshly-registered one")
 }
 
 func TestRunLogin_RejectsInAgentMode(t *testing.T) {

--- a/internal/login/login.go
+++ b/internal/login/login.go
@@ -465,11 +465,11 @@ func exchangeAndValidateTokens(
 	// state — same compensation pattern as the persist-failure branch in
 	// persistAndRevokeOld.
 	if tokenResp.AccessToken == "" {
-		oauth.Revoke(apiURL, authz.ClientID, *tokenResp.RefreshToken)
+		oauth.Revoke(oauth.RevokeRequest{APIURL: apiURL, ClientID: authz.ClientID, RefreshToken: *tokenResp.RefreshToken})
 		return "", "", time.Time{}, errors.New("token exchange succeeded but the server returned an empty access token; aborting")
 	}
 	if tokenResp.ExpiresIn <= 0 {
-		oauth.Revoke(apiURL, authz.ClientID, *tokenResp.RefreshToken)
+		oauth.Revoke(oauth.RevokeRequest{APIURL: apiURL, ClientID: authz.ClientID, RefreshToken: *tokenResp.RefreshToken})
 		return "", "", time.Time{}, fmt.Errorf("token exchange succeeded but the server returned a non-positive expires_in (%d); aborting", tokenResp.ExpiresIn)
 	}
 
@@ -508,7 +508,7 @@ func persistAndRevokeOld(
 		// indefinitely. Best-effort revoke it so the AS state matches what
 		// the user sees locally. Old refresh token is intentionally left
 		// alone: it is still the active session on disk.
-		if !oauth.Revoke(target.APIURL, clientID, refreshToken) {
+		if !oauth.Revoke(oauth.RevokeRequest{APIURL: target.APIURL, ClientID: clientID, RefreshToken: refreshToken}) {
 			return fmt.Errorf(
 				"login succeeded but the new tokens could not be persisted and the compensating revoke also failed; the newly-issued refresh token may still be valid on the authorization server — visit your Dash0 account settings to revoke active sessions manually: %w",
 				err,
@@ -529,7 +529,11 @@ func persistAndRevokeOld(
 		if target.ExistingAPIURL == "" {
 			oldRevoked = false
 		} else {
-			oldRevoked = oauth.Revoke(target.ExistingAPIURL, target.ExistingClientID, target.OldRefresh)
+			oldRevoked = oauth.Revoke(oauth.RevokeRequest{
+				APIURL:       target.ExistingAPIURL,
+				ClientID:     target.ExistingClientID,
+				RefreshToken: target.OldRefresh,
+			})
 		}
 	}
 

--- a/internal/login/login.go
+++ b/internal/login/login.go
@@ -76,12 +76,13 @@ const (
 // new login goes against. Carrying these together lets the phase helpers
 // downstream avoid long parameter lists.
 type loginTarget struct {
-	Name           string       // resolved profile name (user-supplied or active)
-	State          profileState // classification at the start of the flow
-	OldRefresh     string       // refresh token to revoke on successful re-login (OAuth-active only)
-	ExistingAPIURL string       // AS that issued OldRefresh (for cross-tenant revoke directionality)
-	APIURL         string       // AS to authenticate against for the new login
-	PassedExplicit bool         // user passed --profile (vs. implicit active profile)
+	Name             string       // resolved profile name (user-supplied or active)
+	State            profileState // classification at the start of the flow
+	OldRefresh       string       // refresh token to revoke on successful re-login (OAuth-active only)
+	ExistingAPIURL   string       // AS that issued OldRefresh (for cross-tenant revoke directionality)
+	ExistingClientID string       // client_id that issued OldRefresh
+	APIURL           string       // AS to authenticate against for the new login
+	PassedExplicit   bool         // user passed --profile (vs. implicit active profile)
 }
 
 // subjectPhrase returns the noun phrase used in prompts/messages to refer
@@ -184,7 +185,7 @@ func resolveLoginTarget(opts loginOptions) (*loginTarget, error) {
 		profileName = active
 	}
 
-	state, oldRefreshToken, existingAPIURL, err := classifyProfile(profileName)
+	state, oldRefreshToken, existingAPIURL, existingClientID, err := classifyProfile(profileName)
 	if err != nil {
 		return nil, err
 	}
@@ -197,12 +198,13 @@ func resolveLoginTarget(opts loginOptions) (*loginTarget, error) {
 	}
 
 	return &loginTarget{
-		Name:           profileName,
-		State:          state,
-		OldRefresh:     oldRefreshToken,
-		ExistingAPIURL: existingAPIURL,
-		APIURL:         apiURL,
-		PassedExplicit: passedExplicit,
+		Name:             profileName,
+		State:            state,
+		OldRefresh:       oldRefreshToken,
+		ExistingAPIURL:   existingAPIURL,
+		ExistingClientID: existingClientID,
+		APIURL:           apiURL,
+		PassedExplicit:   passedExplicit,
 	}, nil
 }
 
@@ -463,11 +465,11 @@ func exchangeAndValidateTokens(
 	// state — same compensation pattern as the persist-failure branch in
 	// persistAndRevokeOld.
 	if tokenResp.AccessToken == "" {
-		oauth.Revoke(apiURL, *tokenResp.RefreshToken)
+		oauth.Revoke(apiURL, authz.ClientID, *tokenResp.RefreshToken)
 		return "", "", time.Time{}, errors.New("token exchange succeeded but the server returned an empty access token; aborting")
 	}
 	if tokenResp.ExpiresIn <= 0 {
-		oauth.Revoke(apiURL, *tokenResp.RefreshToken)
+		oauth.Revoke(apiURL, authz.ClientID, *tokenResp.RefreshToken)
 		return "", "", time.Time{}, fmt.Errorf("token exchange succeeded but the server returned a non-positive expires_in (%d); aborting", tokenResp.ExpiresIn)
 	}
 
@@ -506,7 +508,7 @@ func persistAndRevokeOld(
 		// indefinitely. Best-effort revoke it so the AS state matches what
 		// the user sees locally. Old refresh token is intentionally left
 		// alone: it is still the active session on disk.
-		if !oauth.Revoke(target.APIURL, refreshToken) {
+		if !oauth.Revoke(target.APIURL, clientID, refreshToken) {
 			return fmt.Errorf(
 				"login succeeded but the new tokens could not be persisted and the compensating revoke also failed; the newly-issued refresh token may still be valid on the authorization server — visit your Dash0 account settings to revoke active sessions manually: %w",
 				err,
@@ -527,7 +529,7 @@ func persistAndRevokeOld(
 		if target.ExistingAPIURL == "" {
 			oldRevoked = false
 		} else {
-			oldRevoked = oauth.Revoke(target.ExistingAPIURL, target.OldRefresh)
+			oldRevoked = oauth.Revoke(target.ExistingAPIURL, target.ExistingClientID, target.OldRefresh)
 		}
 	}
 
@@ -546,14 +548,14 @@ func persistAndRevokeOld(
 // must surface it instead of treating store I/O failures as "no such
 // profile" (which would then proceed to a confusing prompt-then-create
 // flow that ultimately fails on the same I/O error).
-func classifyProfile(name string) (state profileState, oldRefreshToken, existingAPIURL string, err error) {
+func classifyProfile(name string) (state profileState, oldRefreshToken, existingAPIURL, existingClientID string, err error) {
 	store, err := profiles.NewStore()
 	if err != nil {
-		return profileStateMissing, "", "", fmt.Errorf("failed to open profile store: %w", err)
+		return profileStateMissing, "", "", "", fmt.Errorf("failed to open profile store: %w", err)
 	}
 	all, err := store.GetProfiles()
 	if err != nil {
-		return profileStateMissing, "", "", fmt.Errorf("failed to read profiles: %w", err)
+		return profileStateMissing, "", "", "", fmt.Errorf("failed to read profiles: %w", err)
 	}
 	for _, p := range all {
 		if p.Name != name {
@@ -562,16 +564,16 @@ func classifyProfile(name string) (state profileState, oldRefreshToken, existing
 		existingAPIURL = p.Configuration.ApiUrl
 		switch {
 		case p.Configuration.OAuth == nil && p.Configuration.AuthToken == "":
-			return profileStateNoAuth, "", existingAPIURL, nil
+			return profileStateNoAuth, "", existingAPIURL, "", nil
 		case p.Configuration.OAuth == nil:
-			return profileStateStatic, "", existingAPIURL, nil
+			return profileStateStatic, "", existingAPIURL, "", nil
 		case p.Configuration.OAuth.RefreshToken == "":
-			return profileStateOAuthEmpty, "", existingAPIURL, nil
+			return profileStateOAuthEmpty, "", existingAPIURL, "", nil
 		default:
-			return profileStateOAuthActive, p.Configuration.OAuth.RefreshToken, existingAPIURL, nil
+			return profileStateOAuthActive, p.Configuration.OAuth.RefreshToken, existingAPIURL, p.Configuration.OAuth.ClientID, nil
 		}
 	}
-	return profileStateMissing, "", "", nil
+	return profileStateMissing, "", "", "", nil
 }
 
 // resolveTargetAPIURL chooses the API URL to authenticate against. Precedence:

--- a/internal/login/login.go
+++ b/internal/login/login.go
@@ -80,7 +80,7 @@ type loginTarget struct {
 	State            profileState // classification at the start of the flow
 	OldRefresh       string       // refresh token to revoke on successful re-login (OAuth-active only)
 	ExistingAPIURL   string       // AS that issued OldRefresh (for cross-tenant revoke directionality)
-	ExistingClientID string       // client_id that issued OldRefresh
+	ExistingClientID string       // client_id that issued OldRefresh, resolved before any re-registration
 	APIURL           string       // AS to authenticate against for the new login
 	PassedExplicit   bool         // user passed --profile (vs. implicit active profile)
 }
@@ -185,24 +185,24 @@ func resolveLoginTarget(opts loginOptions) (*loginTarget, error) {
 		profileName = active
 	}
 
-	state, oldRefreshToken, existingAPIURL, existingClientID, err := classifyProfile(profileName)
+	existing, err := classifyProfile(profileName)
 	if err != nil {
 		return nil, err
 	}
 
 	// Decide which API URL to authenticate against — flag -> env -> existing
 	// profile -> active profile (only when target is implicit).
-	apiURL, err := resolveTargetAPIURL(opts.APIURL, existingAPIURL, !passedExplicit)
+	apiURL, err := resolveTargetAPIURL(opts.APIURL, existing.APIURL, !passedExplicit)
 	if err != nil {
 		return nil, err
 	}
 
 	return &loginTarget{
 		Name:             profileName,
-		State:            state,
-		OldRefresh:       oldRefreshToken,
-		ExistingAPIURL:   existingAPIURL,
-		ExistingClientID: existingClientID,
+		State:            existing.State,
+		OldRefresh:       existing.RefreshToken,
+		ExistingAPIURL:   existing.APIURL,
+		ExistingClientID: existing.ClientID,
 		APIURL:           apiURL,
 		PassedExplicit:   passedExplicit,
 	}, nil
@@ -464,13 +464,20 @@ func exchangeAndValidateTokens(
 	// revoke it best-effort so the AS state matches the discarded local
 	// state — same compensation pattern as the persist-failure branch in
 	// persistAndRevokeOld.
+	revokeIssued := func() bool {
+		return oauth.Revoke(oauth.RevokeRequest{APIURL: apiURL, ClientID: authz.ClientID, RefreshToken: *tokenResp.RefreshToken})
+	}
 	if tokenResp.AccessToken == "" {
-		oauth.Revoke(oauth.RevokeRequest{APIURL: apiURL, ClientID: authz.ClientID, RefreshToken: *tokenResp.RefreshToken})
-		return "", "", time.Time{}, errors.New("token exchange succeeded but the server returned an empty access token; aborting")
+		return "", "", time.Time{}, withManualRevokeHint(
+			revokeIssued(),
+			errors.New("token exchange succeeded but the server returned an empty access token; aborting"),
+		)
 	}
 	if tokenResp.ExpiresIn <= 0 {
-		oauth.Revoke(oauth.RevokeRequest{APIURL: apiURL, ClientID: authz.ClientID, RefreshToken: *tokenResp.RefreshToken})
-		return "", "", time.Time{}, fmt.Errorf("token exchange succeeded but the server returned a non-positive expires_in (%d); aborting", tokenResp.ExpiresIn)
+		return "", "", time.Time{}, withManualRevokeHint(
+			revokeIssued(),
+			fmt.Errorf("token exchange succeeded but the server returned a non-positive expires_in (%d); aborting", tokenResp.ExpiresIn),
+		)
 	}
 
 	// Cap expires_in defensively so a hostile or buggy AS that returns a
@@ -487,6 +494,22 @@ func exchangeAndValidateTokens(
 	expiresAt = time.Now().Add(time.Duration(cappedExpiresIn) * time.Second)
 
 	return tokenResp.AccessToken, *tokenResp.RefreshToken, expiresAt, nil
+}
+
+// withManualRevokeHint appends a manual-revocation hint to err when the
+// compensating revoke of a just-issued refresh token failed. Every abort
+// that happens after a successful token exchange runs the same
+// compensation, so every one of them reports the same way when the
+// compensation itself does not land — otherwise the user is left with a
+// live refresh token and no indication of it.
+func withManualRevokeHint(revoked bool, err error) error {
+	if revoked {
+		return err
+	}
+	return fmt.Errorf(
+		"%w; the compensating revoke of the newly-issued refresh token also failed, so that token may still be valid on the authorization server — visit your Dash0 account settings to revoke active sessions manually",
+		err,
+	)
 }
 
 // persistAndRevokeOld writes the new OAuth tokens to the profile store,
@@ -508,13 +531,10 @@ func persistAndRevokeOld(
 		// indefinitely. Best-effort revoke it so the AS state matches what
 		// the user sees locally. Old refresh token is intentionally left
 		// alone: it is still the active session on disk.
-		if !oauth.Revoke(oauth.RevokeRequest{APIURL: target.APIURL, ClientID: clientID, RefreshToken: refreshToken}) {
-			return fmt.Errorf(
-				"login succeeded but the new tokens could not be persisted and the compensating revoke also failed; the newly-issued refresh token may still be valid on the authorization server — visit your Dash0 account settings to revoke active sessions manually: %w",
-				err,
-			)
-		}
-		return fmt.Errorf("login succeeded but the new tokens could not be persisted: %w", err)
+		return withManualRevokeHint(
+			oauth.Revoke(oauth.RevokeRequest{APIURL: target.APIURL, ClientID: clientID, RefreshToken: refreshToken}),
+			fmt.Errorf("login succeeded but the new tokens could not be persisted: %w", err),
+		)
 	}
 
 	// Best-effort: revoke the now-superseded refresh token if we just replaced
@@ -544,40 +564,63 @@ func persistAndRevokeOld(
 	return nil
 }
 
-// classifyProfile inspects the named profile (if any) and returns its
-// auth state, the refresh token that should be revoked after a successful
-// new login (only set for OAuth-active), and the existing API URL that
-// should be used as the default when no --api-url flag is given. A non-nil
-// error indicates the profile store could not be opened or read — callers
-// must surface it instead of treating store I/O failures as "no such
-// profile" (which would then proceed to a confusing prompt-then-create
+// existingOAuthState is what classifyProfile learns about the profile login
+// is about to overwrite. Named fields keep the three strings — refresh
+// token, API URL, client ID — from being swapped, the same reason
+// [oauth.RevokeRequest] exists.
+type existingOAuthState struct {
+	State profileState // classification at the moment login starts
+
+	// RefreshToken is the token to revoke after a successful new login.
+	// Only set for OAuth-active.
+	RefreshToken string
+	// APIURL is the AS that issued RefreshToken, and the default to
+	// authenticate against when no --api-url flag is given.
+	APIURL string
+	// ClientID is the client that issued RefreshToken, already resolved
+	// through the DCR cache. Resolving it here rather than inside
+	// oauth.Revoke matters: the cache is keyed by API URL alone, so a
+	// fresh registration later in this same login would otherwise
+	// overwrite the entry and the revoke would go out under a client that
+	// never issued the token.
+	ClientID string
+}
+
+// classifyProfile inspects the named profile (if any) and returns its auth
+// state plus the OAuth state that a successful login will supersede. A
+// non-nil error indicates the profile store could not be opened or read —
+// callers must surface it instead of treating store I/O failures as "no
+// such profile" (which would then proceed to a confusing prompt-then-create
 // flow that ultimately fails on the same I/O error).
-func classifyProfile(name string) (state profileState, oldRefreshToken, existingAPIURL, existingClientID string, err error) {
+func classifyProfile(name string) (existingOAuthState, error) {
 	store, err := profiles.NewStore()
 	if err != nil {
-		return profileStateMissing, "", "", "", fmt.Errorf("failed to open profile store: %w", err)
+		return existingOAuthState{State: profileStateMissing}, fmt.Errorf("failed to open profile store: %w", err)
 	}
 	all, err := store.GetProfiles()
 	if err != nil {
-		return profileStateMissing, "", "", "", fmt.Errorf("failed to read profiles: %w", err)
+		return existingOAuthState{State: profileStateMissing}, fmt.Errorf("failed to read profiles: %w", err)
 	}
 	for _, p := range all {
 		if p.Name != name {
 			continue
 		}
-		existingAPIURL = p.Configuration.ApiUrl
+		existing := existingOAuthState{APIURL: p.Configuration.ApiUrl}
 		switch {
 		case p.Configuration.OAuth == nil && p.Configuration.AuthToken == "":
-			return profileStateNoAuth, "", existingAPIURL, "", nil
+			existing.State = profileStateNoAuth
 		case p.Configuration.OAuth == nil:
-			return profileStateStatic, "", existingAPIURL, "", nil
+			existing.State = profileStateStatic
 		case p.Configuration.OAuth.RefreshToken == "":
-			return profileStateOAuthEmpty, "", existingAPIURL, "", nil
+			existing.State = profileStateOAuthEmpty
 		default:
-			return profileStateOAuthActive, p.Configuration.OAuth.RefreshToken, existingAPIURL, p.Configuration.OAuth.ClientID, nil
+			existing.State = profileStateOAuthActive
+			existing.RefreshToken = p.Configuration.OAuth.RefreshToken
+			existing.ClientID = profiles.ResolveOAuthClientID(existing.APIURL, p.Configuration.OAuth.ClientID)
 		}
+		return existing, nil
 	}
-	return profileStateMissing, "", "", "", nil
+	return existingOAuthState{State: profileStateMissing}, nil
 }
 
 // resolveTargetAPIURL chooses the API URL to authenticate against. Precedence:

--- a/internal/login/logout.go
+++ b/internal/login/logout.go
@@ -134,8 +134,12 @@ func runLogout(ctx context.Context, opts logoutOptions) error {
 
 	// Best-effort revocation before we clear the in-memory copy on disk.
 	revoked := oauth.Revoke(oauth.RevokeRequest{
-		APIURL:       cfg.ApiUrl,
-		ClientID:     cfg.OAuth.ClientID,
+		APIURL: cfg.ApiUrl,
+		// Resolve a profile written without a stored ClientID through the
+		// DCR cache here, at read time: oauth.Revoke uses the field
+		// verbatim so no caller can accidentally revoke under a client
+		// that a later registration wrote into the cache.
+		ClientID:     profiles.ResolveOAuthClientID(cfg.ApiUrl, cfg.OAuth.ClientID),
 		RefreshToken: cfg.OAuth.RefreshToken,
 	})
 

--- a/internal/login/logout.go
+++ b/internal/login/logout.go
@@ -133,7 +133,11 @@ func runLogout(ctx context.Context, opts logoutOptions) error {
 	}
 
 	// Best-effort revocation before we clear the in-memory copy on disk.
-	revoked := oauth.Revoke(cfg.ApiUrl, cfg.OAuth.ClientID, cfg.OAuth.RefreshToken)
+	revoked := oauth.Revoke(oauth.RevokeRequest{
+		APIURL:       cfg.ApiUrl,
+		ClientID:     cfg.OAuth.ClientID,
+		RefreshToken: cfg.OAuth.RefreshToken,
+	})
 
 	if err := store.UpdateProfile(name, func(c *profiles.Configuration) {
 		c.AuthToken = ""

--- a/internal/login/logout.go
+++ b/internal/login/logout.go
@@ -133,7 +133,7 @@ func runLogout(ctx context.Context, opts logoutOptions) error {
 	}
 
 	// Best-effort revocation before we clear the in-memory copy on disk.
-	revoked := oauth.Revoke(cfg.ApiUrl, cfg.OAuth.RefreshToken)
+	revoked := oauth.Revoke(cfg.ApiUrl, cfg.OAuth.ClientID, cfg.OAuth.RefreshToken)
 
 	if err := store.UpdateProfile(name, func(c *profiles.Configuration) {
 		c.AuthToken = ""

--- a/internal/oauth/revoke.go
+++ b/internal/oauth/revoke.go
@@ -11,10 +11,14 @@ package oauth
 import (
 	"context"
 	"fmt"
+	"net/http"
+	"net/url"
 	"os"
+	"strings"
 	"time"
 
 	dash0api "github.com/dash0hq/dash0-api-client-go"
+	"github.com/dash0hq/dash0-cli/internal/version"
 )
 
 // revokeTimeout bounds the revocation HTTP call. A slow or unresponsive
@@ -22,30 +26,44 @@ import (
 // — the local state has already been updated by the time the revoke runs.
 const revokeTimeout = 5 * time.Second
 
-// Revoke posts a revocation request for refreshToken against apiURL.
-// Errors are logged to stderr with a `warning:` prefix; the function
+// Revoke posts a revocation request for refreshToken, as clientID, against
+// apiURL. Errors are logged to stderr with a `warning:` prefix; the function
 // returns true on success (or no-op) and false on failure so callers can
 // optionally append a note to their success message. Callers rely on
 // this function returning promptly regardless of outcome.
-// No-ops (and returns true) when either argument is empty.
-func Revoke(apiURL, refreshToken string) (ok bool) {
+// No-ops (and returns true) when refreshToken or apiURL is empty.
+//
+// Uses the generated client's raw-body form-data method instead of the
+// typed [dash0api.OAuthClient.RevokeToken] because dash0-api-client-go's
+// OAuthRevocationRequest has no ClientId field yet; switch back to the
+// typed call once it does.
+func Revoke(apiURL, clientID, refreshToken string) (ok bool) {
 	if refreshToken == "" || apiURL == "" {
 		return true
 	}
-	client, err := dash0api.NewOAuthClient(dash0api.WithApiUrl(apiURL))
+	userAgentEditor := func(_ context.Context, req *http.Request) error {
+		req.Header.Set("User-Agent", version.UserAgent())
+		return nil
+	}
+	inner, err := dash0api.NewClientWithResponses(apiURL, dash0api.WithRequestEditorFn(userAgentEditor))
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "warning: failed to construct OAuth client to revoke refresh token: %v\n", err)
 		return false
 	}
-	defer func() { _ = client.Close(context.Background()) }()
+	form := url.Values{
+		"token":           {refreshToken},
+		"token_type_hint": {"refresh_token"},
+		"client_id":       {clientID},
+	}
 	ctx, cancel := context.WithTimeout(context.Background(), revokeTimeout)
 	defer cancel()
-	hint := dash0api.OAuthTokenTypeRefreshToken
-	if err := client.RevokeToken(ctx, &dash0api.OAuthRevocationRequest{
-		Token:         refreshToken,
-		TokenTypeHint: &hint,
-	}); err != nil {
+	resp, err := inner.PostOauthRevokeWithBodyWithResponse(ctx, "application/x-www-form-urlencoded", strings.NewReader(form.Encode()))
+	if err != nil {
 		fmt.Fprintf(os.Stderr, "warning: refresh token revocation failed (it may already be invalid): %v\n", err)
+		return false
+	}
+	if status := resp.StatusCode(); status < 200 || status >= 300 {
+		fmt.Fprintf(os.Stderr, "warning: refresh token revocation failed (it may already be invalid): unexpected status %s\n", resp.Status())
 		return false
 	}
 	return true

--- a/internal/oauth/revoke.go
+++ b/internal/oauth/revoke.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	dash0api "github.com/dash0hq/dash0-api-client-go"
+	"github.com/dash0hq/dash0-api-client-go/profiles"
 	"github.com/dash0hq/dash0-cli/internal/version"
 )
 
@@ -53,11 +54,14 @@ func Revoke(req RevokeRequest) (ok bool) {
 	ctx, cancel := context.WithTimeout(context.Background(), revokeTimeout)
 	defer cancel()
 	hint := dash0api.OAuthTokenTypeRefreshToken
-	if err := client.RevokeToken(ctx, &dash0api.OAuthRevocationRequest{
-		ClientId:      req.ClientID,
+	revokeReq := &dash0api.OAuthRevocationRequest{
 		Token:         req.RefreshToken,
 		TokenTypeHint: &hint,
-	}); err != nil {
+	}
+	if clientID := profiles.ResolveOAuthClientID(req.APIURL, req.ClientID); clientID != "" {
+		revokeReq.ClientId = clientID
+	}
+	if err := client.RevokeToken(ctx, revokeReq); err != nil {
 		fmt.Fprintf(os.Stderr, "warning: refresh token revocation failed (it may already be invalid): %v\n", err)
 		return false
 	}

--- a/internal/oauth/revoke.go
+++ b/internal/oauth/revoke.go
@@ -23,18 +23,26 @@ import (
 // — the local state has already been updated by the time the revoke runs.
 const revokeTimeout = 5 * time.Second
 
-// Revoke posts a revocation request for refreshToken, as clientID, against
-// apiURL. Errors are logged to stderr with a `warning:` prefix; the function
-// returns true on success (or no-op) and false on failure so callers can
-// optionally append a note to their success message. Callers rely on
-// this function returning promptly regardless of outcome.
-// No-ops (and returns true) when refreshToken or apiURL is empty.
-func Revoke(apiURL, clientID, refreshToken string) (ok bool) {
-	if refreshToken == "" || apiURL == "" {
+// RevokeRequest is the input to [Revoke]. Named fields keep API URL, client
+// ID, and refresh token from being swapped at the six call sites.
+type RevokeRequest struct {
+	APIURL       string
+	ClientID     string
+	RefreshToken string
+}
+
+// Revoke posts a revocation request for req.RefreshToken, as req.ClientID,
+// against req.APIURL. Errors are logged to stderr with a `warning:` prefix;
+// the function returns true on success (or no-op) and false on failure so
+// callers can optionally append a note to their success message. Callers
+// rely on this function returning promptly regardless of outcome.
+// No-ops (and returns true) when RefreshToken or APIURL is empty.
+func Revoke(req RevokeRequest) (ok bool) {
+	if req.RefreshToken == "" || req.APIURL == "" {
 		return true
 	}
 	client, err := dash0api.NewOAuthClient(
-		dash0api.WithApiUrl(apiURL),
+		dash0api.WithApiUrl(req.APIURL),
 		dash0api.WithUserAgent(version.UserAgent()),
 	)
 	if err != nil {
@@ -46,8 +54,8 @@ func Revoke(apiURL, clientID, refreshToken string) (ok bool) {
 	defer cancel()
 	hint := dash0api.OAuthTokenTypeRefreshToken
 	if err := client.RevokeToken(ctx, &dash0api.OAuthRevocationRequest{
-		ClientId:      clientID,
-		Token:         refreshToken,
+		ClientId:      req.ClientID,
+		Token:         req.RefreshToken,
 		TokenTypeHint: &hint,
 	}); err != nil {
 		fmt.Fprintf(os.Stderr, "warning: refresh token revocation failed (it may already be invalid): %v\n", err)

--- a/internal/oauth/revoke.go
+++ b/internal/oauth/revoke.go
@@ -15,7 +15,6 @@ import (
 	"time"
 
 	dash0api "github.com/dash0hq/dash0-api-client-go"
-	"github.com/dash0hq/dash0-api-client-go/profiles"
 	"github.com/dash0hq/dash0-cli/internal/version"
 )
 
@@ -26,6 +25,14 @@ const revokeTimeout = 5 * time.Second
 
 // RevokeRequest is the input to [Revoke]. Named fields keep API URL, client
 // ID, and refresh token from being swapped at the six call sites.
+//
+// ClientID is used verbatim. [Revoke] deliberately does not fall back to the
+// DCR client cache when it is empty: that cache is keyed by API URL alone, so
+// on the re-login path a fresh registration has already overwritten the entry
+// by the time the old token is revoked, and the revoke would go out under a
+// client that never issued it — the AS answers 200 without revoking anything.
+// Callers that read a stored profile resolve the client ID at read time
+// through profiles.ResolveOAuthClientID, before any registration runs.
 type RevokeRequest struct {
 	APIURL       string
 	ClientID     string
@@ -35,8 +42,9 @@ type RevokeRequest struct {
 // Revoke posts a revocation request for req.RefreshToken, as req.ClientID,
 // against req.APIURL. Errors are logged to stderr with a `warning:` prefix;
 // the function returns true on success (or no-op) and false on failure so
-// callers can optionally append a note to their success message. Callers
-// rely on this function returning promptly regardless of outcome.
+// callers can optionally append a note to their success message. The
+// function performs one bounded network call and no disk I/O, so callers can
+// rely on it returning promptly regardless of outcome.
 // No-ops (and returns true) when RefreshToken or APIURL is empty.
 func Revoke(req RevokeRequest) (ok bool) {
 	if req.RefreshToken == "" || req.APIURL == "" {
@@ -58,8 +66,8 @@ func Revoke(req RevokeRequest) (ok bool) {
 		Token:         req.RefreshToken,
 		TokenTypeHint: &hint,
 	}
-	if clientID := profiles.ResolveOAuthClientID(req.APIURL, req.ClientID); clientID != "" {
-		revokeReq.ClientId = clientID
+	if req.ClientID != "" {
+		revokeReq.ClientId = req.ClientID
 	}
 	if err := client.RevokeToken(ctx, revokeReq); err != nil {
 		fmt.Fprintf(os.Stderr, "warning: refresh token revocation failed (it may already be invalid): %v\n", err)

--- a/internal/oauth/revoke.go
+++ b/internal/oauth/revoke.go
@@ -11,10 +11,7 @@ package oauth
 import (
 	"context"
 	"fmt"
-	"net/http"
-	"net/url"
 	"os"
-	"strings"
 	"time"
 
 	dash0api "github.com/dash0hq/dash0-api-client-go"
@@ -32,38 +29,28 @@ const revokeTimeout = 5 * time.Second
 // optionally append a note to their success message. Callers rely on
 // this function returning promptly regardless of outcome.
 // No-ops (and returns true) when refreshToken or apiURL is empty.
-//
-// Uses the generated client's raw-body form-data method instead of the
-// typed [dash0api.OAuthClient.RevokeToken] because dash0-api-client-go's
-// OAuthRevocationRequest has no ClientId field yet; switch back to the
-// typed call once it does.
 func Revoke(apiURL, clientID, refreshToken string) (ok bool) {
 	if refreshToken == "" || apiURL == "" {
 		return true
 	}
-	userAgentEditor := func(_ context.Context, req *http.Request) error {
-		req.Header.Set("User-Agent", version.UserAgent())
-		return nil
-	}
-	inner, err := dash0api.NewClientWithResponses(apiURL, dash0api.WithRequestEditorFn(userAgentEditor))
+	client, err := dash0api.NewOAuthClient(
+		dash0api.WithApiUrl(apiURL),
+		dash0api.WithUserAgent(version.UserAgent()),
+	)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "warning: failed to construct OAuth client to revoke refresh token: %v\n", err)
 		return false
 	}
-	form := url.Values{
-		"token":           {refreshToken},
-		"token_type_hint": {"refresh_token"},
-		"client_id":       {clientID},
-	}
+	defer func() { _ = client.Close(context.Background()) }()
 	ctx, cancel := context.WithTimeout(context.Background(), revokeTimeout)
 	defer cancel()
-	resp, err := inner.PostOauthRevokeWithBodyWithResponse(ctx, "application/x-www-form-urlencoded", strings.NewReader(form.Encode()))
-	if err != nil {
+	hint := dash0api.OAuthTokenTypeRefreshToken
+	if err := client.RevokeToken(ctx, &dash0api.OAuthRevocationRequest{
+		ClientId:      clientID,
+		Token:         refreshToken,
+		TokenTypeHint: &hint,
+	}); err != nil {
 		fmt.Fprintf(os.Stderr, "warning: refresh token revocation failed (it may already be invalid): %v\n", err)
-		return false
-	}
-	if status := resp.StatusCode(); status < 200 || status >= 300 {
-		fmt.Fprintf(os.Stderr, "warning: refresh token revocation failed (it may already be invalid): unexpected status %s\n", resp.Status())
 		return false
 	}
 	return true

--- a/internal/oauth/revoke_test.go
+++ b/internal/oauth/revoke_test.go
@@ -1,0 +1,54 @@
+package oauth
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRevoke_SendsClientID(t *testing.T) {
+	var gotForm url.Values
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/oauth/revoke", r.URL.Path)
+		require.Equal(t, http.MethodPost, r.Method)
+		require.Equal(t, "application/x-www-form-urlencoded", r.Header.Get("Content-Type"))
+		require.NoError(t, r.ParseForm())
+		gotForm = r.Form
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	ok := Revoke(server.URL, "client-abc-123", "dash0_rt_test")
+	assert.True(t, ok)
+	require.NotNil(t, gotForm)
+	assert.Equal(t, "dash0_rt_test", gotForm.Get("token"))
+	assert.Equal(t, "refresh_token", gotForm.Get("token_type_hint"))
+	assert.Equal(t, "client-abc-123", gotForm.Get("client_id"))
+}
+
+func TestRevoke_AcceptsNoContentStatus(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+
+	assert.True(t, Revoke(server.URL, "client-abc-123", "dash0_rt_test"))
+}
+
+func TestRevoke_FailureReturnsFalse(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+	}))
+	defer server.Close()
+
+	assert.False(t, Revoke(server.URL, "client-abc-123", "dash0_rt_test"))
+}
+
+func TestRevoke_NoOpsOnEmptyArgs(t *testing.T) {
+	assert.True(t, Revoke("", "client-abc-123", "dash0_rt_test"), "empty apiURL should no-op")
+	assert.True(t, Revoke("https://api.example.com", "client-abc-123", ""), "empty refreshToken should no-op")
+}

--- a/internal/oauth/revoke_test.go
+++ b/internal/oauth/revoke_test.go
@@ -14,10 +14,13 @@ import (
 func TestRevoke_SendsClientID(t *testing.T) {
 	var gotForm url.Values
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		require.Equal(t, "/oauth/revoke", r.URL.Path)
-		require.Equal(t, http.MethodPost, r.Method)
-		require.Equal(t, "application/x-www-form-urlencoded", r.Header.Get("Content-Type"))
-		require.NoError(t, r.ParseForm())
+		assert.Equal(t, "/oauth/revoke", r.URL.Path)
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "application/x-www-form-urlencoded", r.Header.Get("Content-Type"))
+		if !assert.NoError(t, r.ParseForm()) {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
 		gotForm = r.Form
 		w.WriteHeader(http.StatusOK)
 	}))
@@ -59,7 +62,10 @@ func TestRevoke_OmitsEmptyClientID(t *testing.T) {
 
 	var gotForm url.Values
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		require.NoError(t, r.ParseForm())
+		if !assert.NoError(t, r.ParseForm()) {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
 		gotForm = r.Form
 		w.WriteHeader(http.StatusOK)
 	}))
@@ -71,13 +77,22 @@ func TestRevoke_OmitsEmptyClientID(t *testing.T) {
 	assert.False(t, present, "empty client_id must be omitted, not sent as an empty parameter")
 }
 
-func TestRevoke_FallsBackToDCRCache(t *testing.T) {
-	dir := t.TempDir()
-	t.Setenv("DASH0_CONFIG_DIR", dir)
+// TestRevoke_IgnoresDCRCache pins down that an empty ClientID stays empty.
+// Falling back to the DCR client cache here would be wrong: the cache is
+// keyed by API URL alone, so on the re-login path a fresh registration has
+// already overwritten the entry by the time the superseded token is
+// revoked, and the revoke would go out under a client that never issued it
+// — the AS answers 200 and revokes nothing. Callers resolve the client ID
+// at profile-read time instead, before any registration runs.
+func TestRevoke_IgnoresDCRCache(t *testing.T) {
+	t.Setenv("DASH0_CONFIG_DIR", t.TempDir())
 
 	var gotForm url.Values
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		require.NoError(t, r.ParseForm())
+		if !assert.NoError(t, r.ParseForm()) {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
 		gotForm = r.Form
 		w.WriteHeader(http.StatusOK)
 	}))
@@ -92,5 +107,6 @@ func TestRevoke_FallsBackToDCRCache(t *testing.T) {
 
 	assert.True(t, Revoke(RevokeRequest{APIURL: server.URL, RefreshToken: "dash0_rt_test"}))
 	require.NotNil(t, gotForm)
-	assert.Equal(t, "cached-from-dcr", gotForm.Get("client_id"))
+	_, present := gotForm["client_id"]
+	assert.False(t, present, "Revoke must not read the DCR cache; an empty ClientID stays omitted")
 }

--- a/internal/oauth/revoke_test.go
+++ b/internal/oauth/revoke_test.go
@@ -6,6 +6,7 @@ import (
 	"net/url"
 	"testing"
 
+	"github.com/dash0hq/dash0-api-client-go/profiles"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -51,4 +52,45 @@ func TestRevoke_FailureReturnsFalse(t *testing.T) {
 func TestRevoke_NoOpsOnEmptyArgs(t *testing.T) {
 	assert.True(t, Revoke(RevokeRequest{ClientID: "client-abc-123", RefreshToken: "dash0_rt_test"}), "empty apiURL should no-op")
 	assert.True(t, Revoke(RevokeRequest{APIURL: "https://api.example.com", ClientID: "client-abc-123"}), "empty refreshToken should no-op")
+}
+
+func TestRevoke_OmitsEmptyClientID(t *testing.T) {
+	t.Setenv("DASH0_CONFIG_DIR", t.TempDir())
+
+	var gotForm url.Values
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.NoError(t, r.ParseForm())
+		gotForm = r.Form
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	assert.True(t, Revoke(RevokeRequest{APIURL: server.URL, RefreshToken: "dash0_rt_test"}))
+	require.NotNil(t, gotForm)
+	_, present := gotForm["client_id"]
+	assert.False(t, present, "empty client_id must be omitted, not sent as an empty parameter")
+}
+
+func TestRevoke_FallsBackToDCRCache(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("DASH0_CONFIG_DIR", dir)
+
+	var gotForm url.Values
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.NoError(t, r.ParseForm())
+		gotForm = r.Form
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	store, err := profiles.NewOAuthClientStore()
+	require.NoError(t, err)
+	require.NoError(t, store.Put(server.URL, profiles.OAuthClientRecord{
+		ClientID:    "cached-from-dcr",
+		RedirectURI: "http://localhost/cb",
+	}))
+
+	assert.True(t, Revoke(RevokeRequest{APIURL: server.URL, RefreshToken: "dash0_rt_test"}))
+	require.NotNil(t, gotForm)
+	assert.Equal(t, "cached-from-dcr", gotForm.Get("client_id"))
 }

--- a/internal/oauth/revoke_test.go
+++ b/internal/oauth/revoke_test.go
@@ -22,7 +22,7 @@ func TestRevoke_SendsClientID(t *testing.T) {
 	}))
 	defer server.Close()
 
-	ok := Revoke(server.URL, "client-abc-123", "dash0_rt_test")
+	ok := Revoke(RevokeRequest{APIURL: server.URL, ClientID: "client-abc-123", RefreshToken: "dash0_rt_test"})
 	assert.True(t, ok)
 	require.NotNil(t, gotForm)
 	assert.Equal(t, "dash0_rt_test", gotForm.Get("token"))
@@ -36,7 +36,7 @@ func TestRevoke_AcceptsNoContentStatus(t *testing.T) {
 	}))
 	defer server.Close()
 
-	assert.True(t, Revoke(server.URL, "client-abc-123", "dash0_rt_test"))
+	assert.True(t, Revoke(RevokeRequest{APIURL: server.URL, ClientID: "client-abc-123", RefreshToken: "dash0_rt_test"}))
 }
 
 func TestRevoke_FailureReturnsFalse(t *testing.T) {
@@ -45,10 +45,10 @@ func TestRevoke_FailureReturnsFalse(t *testing.T) {
 	}))
 	defer server.Close()
 
-	assert.False(t, Revoke(server.URL, "client-abc-123", "dash0_rt_test"))
+	assert.False(t, Revoke(RevokeRequest{APIURL: server.URL, ClientID: "client-abc-123", RefreshToken: "dash0_rt_test"}))
 }
 
 func TestRevoke_NoOpsOnEmptyArgs(t *testing.T) {
-	assert.True(t, Revoke("", "client-abc-123", "dash0_rt_test"), "empty apiURL should no-op")
-	assert.True(t, Revoke("https://api.example.com", "client-abc-123", ""), "empty refreshToken should no-op")
+	assert.True(t, Revoke(RevokeRequest{ClientID: "client-abc-123", RefreshToken: "dash0_rt_test"}), "empty apiURL should no-op")
+	assert.True(t, Revoke(RevokeRequest{APIURL: "https://api.example.com", ClientID: "client-abc-123"}), "empty refreshToken should no-op")
 }


### PR DESCRIPTION
## Summary
Send `client_id` on OAuth token revocation by going through `OAuthClient.RevokeToken` instead of a raw form POST.

## Why
The authorization server requires `client_id` on `POST /oauth/revoke` (RFC 7009 §2.1). Without it, `logout`, re-login, and `config profiles update --oauth=false` left the refresh token valid server-side.

The shared part landed upstream in https://github.com/dash0hq/dash0-api-client-go/pull/31, which adds `ClientId` to `OAuthRevocationRequest` so the Terraform provider benefits too. `go.mod` pins `dash0-api-client-go v1.21.1`; there is no local `replace` directive.

## Also in this PR
- `oauth.RevokeRequest` so API URL / client ID / refresh token cannot be swapped at the six call sites
- The client ID is resolved at profile-read time, not inside `oauth.Revoke`. The DCR client cache is keyed by API URL alone, so resolving it inside `Revoke` meant a re-login's fresh registration had already overwritten the entry by the time the superseded token was revoked — the revoke went out under a client that never issued it, and the AS answered 200 without revoking anything.
- `withManualRevokeHint`, so every abort after a successful token exchange reports the same way when its compensating revoke also fails
- `existingOAuthState` replaces `classifyProfile`'s five-value return
- httptest handlers no longer `FailNow` on the server goroutine, and the fake AS answers `400 invalid_client` on a missing `client_id` rather than flagging it and returning 200 anyway

## Tests
- [x] Revoke request body includes `client_id`
- [x] An empty client ID is omitted, not sent as `client_id=`
- [x] `--oauth=false` revoke path
- [x] Re-login revokes the old token with the old client's ID, not the new one
- [x] Re-login on a profile with no stored client ID never revokes under the freshly-registered one
- [x] `logout` on a profile with no stored client ID resolves it from the DCR cache
- [x] Session-expired error message, interactive + agent mode
