### PR TITLE
chore(nix): automate flake.lock updates on a weekly schedule and before releases

### DIFF
--- a/.github/workflows/nix-flake-update.yml
+++ b/.github/workflows/nix-flake-update.yml
@@ -1,0 +1,69 @@
+name: Nix flake update
+
+# Keeps flake.lock from going stale. cache.nixos.org only retains binaries for
+# a nixos-unstable revision for a limited window before garbage-collecting
+# them, so an old pin eventually forces `nix build`/`nix run`/`nix profile
+# install` to rebuild the whole dependency closure from source instead of
+# substituting cached binaries -- or fails outright if an upstream source has
+# disappeared.
+#
+# Dependabot does not support the Nix ecosystem, so this workflow fills that
+# gap on its own weekly schedule, decoupled from the release cadence (see
+# prepare-release.yml for the validated release-time update, and
+# nix/update-flake-lock.sh for the shared update+validate logic both use). A
+# nixpkgs/flake-utils bump is its own risk surface -- keeping it on an
+# independent cadence, reviewed and merged like any other dependency PR,
+# avoids conflating "did the release break" with "did nixpkgs break".
+on:
+  schedule:
+    - cron: '0 6 * * 1' # Every Monday at 06:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  update-flake-lock:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          token: ${{ secrets.REPOSITORY_FULL_ACCESS_GITHUB_TOKEN }}
+
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@ef8a148080ab6020fd15196c2084a2eea5ff2d25 # v22
+
+      - name: Update flake.lock
+        run: ./nix/update-flake-lock.sh
+
+      - name: Open or update pull request
+        env:
+          GH_TOKEN: ${{ secrets.REPOSITORY_FULL_ACCESS_GITHUB_TOKEN }}
+        run: |
+          if git diff --quiet -- flake.lock; then
+            echo "flake.lock already up to date; nothing to do."
+            exit 0
+          fi
+
+          # A single bot-owned branch, force-pushed each run: keeps one open
+          # PR at a time instead of piling up a new one every week.
+          BRANCH="chore/update-flake-lock"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git checkout -B "$BRANCH"
+          git add flake.lock
+          git commit -m "chore(nix): update flake.lock"
+          git push --force origin "$BRANCH"
+
+          if gh pr view "$BRANCH" >/dev/null 2>&1; then
+            echo "Pull request for $BRANCH already open; pushed the new update to it."
+          else
+            gh pr create \
+              --title "chore(nix): update flake.lock" \
+              --body "Updates the nixpkgs and flake-utils revisions pinned in \`flake.lock\`, validated with \`nix build .#dash0\` and \`nix flake check\` (see \`nix/update-flake-lock.sh\`)." \
+              --label dependencies \
+              --label "Skip Changelog" \
+              --base main \
+              --head "$BRANCH"
+          fi

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -85,15 +85,27 @@ jobs:
           # Fail loudly if the literal moved and the sed matched nothing.
           grep -q 'version = "${{ steps.version.outputs.version }}";' flake.nix
 
+      # Also refresh the nixpkgs/flake-utils pin as part of cutting a release,
+      # so a release is never shipped on a pin older than the last weekly
+      # nix-flake-update.yml run. Self-validating: if the newer revision
+      # fails to build dash0, the script discards the attempt and leaves
+      # flake.lock untouched, so a broken upstream nixpkgs revision never
+      # blocks (or ships in) a release.
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@ef8a148080ab6020fd15196c2084a2eea5ff2d25 # v22
+
+      - name: Update flake.lock
+        run: ./nix/update-flake-lock.sh
+
       - name: Commit and push changelog
         env:
           GH_TOKEN: ${{ secrets.REPOSITORY_FULL_ACCESS_GITHUB_TOKEN }}
         run: |
           gh auth setup-git
           git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           find .chloggen -name "*.yaml" ! -name "config.yaml" ! -name "TEMPLATE.yaml" -exec git rm -f {} + 2>/dev/null || true
-          git add CHANGELOG.md .chloggen flake.nix
+          git add CHANGELOG.md .chloggen flake.nix flake.lock
           git commit -m "chore: update changelog and version for v${{ steps.version.outputs.version }}"
           git push origin main
 
@@ -103,7 +115,7 @@ jobs:
         run: |
           gh auth setup-git
           git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git tag v${{ steps.version.outputs.version }}
           git push origin v${{ steps.version.outputs.version }}
 

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -109,7 +109,7 @@ brews:
       name: dash0-cli
     commit_author:
       name: github-actions[bot]
-      email: github-actions[bot]@users.noreply.github.com
+      email: 41898282+github-actions[bot]@users.noreply.github.com
     commit_msg_template: "chore: brew formula update for {{ .ProjectName }} version {{ .Tag }}"
     directory: Formula
     homepage: https://github.com/dash0hq/dash0-cli
@@ -131,7 +131,7 @@ homebrew_casks:
       name: homebrew-dash0-cli
     commit_author:
       name: github-actions[bot]
-      email: github-actions[bot]@users.noreply.github.com
+      email: 41898282+github-actions[bot]@users.noreply.github.com
     commit_msg_template: "release: dash0-cli/{{ .Version }}"
     homepage: https://github.com/dash0hq/dash0-cli
     description: CLI to interact with Dash0
@@ -171,7 +171,7 @@ nix:
       name: nur
     commit_author:
       name: github-actions[bot]
-      email: github-actions[bot]@users.noreply.github.com
+      email: 41898282+github-actions[bot]@users.noreply.github.com
     commit_msg_template: "release: dash0/{{ .Version }}"
     homepage: https://github.com/dash0hq/dash0-cli
     description: CLI to interact with Dash0

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all build clean test test-unit test-integration test-roundtrip install lint lint-install lint-go-install lint-sh-install lint-go lint-sh chlog-install chlog-new chlog-validate chlog-preview chlog-update update-vendor-hash skill-bundle skill-validate
+.PHONY: all build clean test test-unit test-integration test-roundtrip install lint lint-install lint-go-install lint-sh-install lint-go lint-sh chlog-install chlog-new chlog-validate chlog-preview chlog-update update-vendor-hash update-flake-lock skill-bundle skill-validate
 
 all: lint test
 
@@ -35,6 +35,12 @@ install: build
 # Requires Nix with flakes enabled.
 update-vendor-hash:
 	./nix/update-vendor-hash.sh
+
+# Update flake.lock to the latest nixpkgs/flake-utils revisions, validating
+# that dash0 still builds before leaving the update in place. Requires Nix
+# with flakes enabled.
+update-flake-lock:
+	./nix/update-flake-lock.sh
 
 lint: lint-go lint-sh skill-validate
 

--- a/README.md
+++ b/README.md
@@ -140,6 +140,10 @@ Multi-architecture images (`linux/amd64`, `linux/arm64`) are published to GitHub
 
 The repository is a Nix flake that builds the CLI with `buildGoModule` and installs shell completions for Bash, Zsh, and Fish.
 
+> [!NOTE]
+> `flake.lock` pins the exact `nixpkgs` and `flake-utils` revisions used to build `dash0`.
+> A weekly workflow (`.github/workflows/nix-flake-update.yml`) refreshes that pin automatically, and every release re-validates it once more before shipping, so `nix build`/`nix run`/`nix profile install` keep getting a revision `cache.nixos.org` still has pre-built binaries for, instead of falling back to a from-source rebuild once an old pin ages out of the cache.
+
 Run the CLI without installing it:
 
 ```bash

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -30,6 +30,9 @@ Multi-architecture images (`linux/amd64`, `linux/arm64`) are published to the Gi
 
 The repository is published as a Nix flake.
 
+> [!NOTE]
+> `flake.lock`'s `nixpkgs` pin is refreshed automatically on a weekly schedule and re-validated on every release, so `nix build`/`nix run`/`nix profile install` keep resolving to a revision `cache.nixos.org` still has pre-built binaries for.
+
 Run without installing:
 
 ```bash

--- a/nix/update-flake-lock.sh
+++ b/nix/update-flake-lock.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+#
+# Update flake.lock to the latest nixpkgs/flake-utils revisions, then validate
+# that dash0 still builds against the new pin before leaving it in place.
+#
+# If the update produces a revision that fails to build, the attempt is
+# discarded and flake.lock is restored to its original content -- a broken
+# upstream nixpkgs revision must never be the thing that leaves flake.lock in
+# a bad state. Idempotent: when there is nothing newer to pin, flake.lock is
+# left unchanged.
+#
+# Run from the repository root (or via `make update-flake-lock`). Requires Nix
+# with flakes enabled. Shared by .github/workflows/nix-flake-update.yml (weekly
+# schedule) and .github/workflows/prepare-release.yml (validated update right
+# before cutting a release), so neither path can ship a broken nixpkgs pin.
+set -euo pipefail
+
+if [ ! -f "flake.lock" ] || [ ! -f "flake.nix" ]; then
+  echo "error: run this from the repository root (cannot find flake.lock / flake.nix)" >&2
+  exit 1
+fi
+
+if ! command -v nix >/dev/null 2>&1; then
+  echo "error: nix is not installed or not on PATH" >&2
+  exit 1
+fi
+
+backup="$(mktemp)"
+trap 'rm -f "$backup"' EXIT
+cp flake.lock "$backup"
+
+nix flake update
+
+if [ "$(sha256sum <flake.lock)" = "$(sha256sum <"$backup")" ]; then
+  echo "flake.lock already up to date."
+  exit 0
+fi
+
+if nix build .#dash0 --print-build-logs && nix flake check --print-build-logs; then
+  echo "flake.lock updated and validated."
+else
+  echo "::warning::New nixpkgs/flake-utils revision failed to build dash0 or failed flake checks; keeping the previous flake.lock pin." >&2
+  cp "$backup" flake.lock
+fi


### PR DESCRIPTION
Add a regular (weekly) update job for `flake.lock`'s `nixpkgs`/`flake-utils`. `cache.nixos.org` only retains binaries for a `nixos-unstable` revision for a limited window, so an old pin eventually forces `nix build`/`nix run`/`nix profile install` into a from-source rebuild instead of substituting cached binaries.