### PR TITLE
fix(auth): refresh OAuth tokens for the whole duration of a command

### DIFF
--- a/.chloggen/iac-1-oauth-token-refresh.yaml
+++ b/.chloggen/iac-1-oauth-token-refresh.yaml
@@ -1,0 +1,24 @@
+change_type: bug_fix
+
+component: auth
+
+note: Refresh OAuth access tokens for the whole duration of a command, not just at startup
+
+issues: [258]
+
+subtext: |
+  An OAuth access token lasts 15 minutes, and the CLI resolved it once at startup then reused
+  it for the rest of the command. Anything that ran longer failed partway through with
+  `authentication failed; check your auth token (status: 401)`, leaving partial output. Large
+  exports hit this most often, such as `dash0 logs query --from now-7d -o json`, along with
+  bulk `dash0 apply -f` runs and `list` over many assets.
+
+  The token is now resolved before every request and refreshed as it nears expiry, so a long
+  command finishes on one `dash0 login`. A request rejected with 401 is retried once with a
+  fresh token, which also covers a token revoked elsewhere and clock skew against the
+  authorization server.
+
+  `--profile <name>` and `DASH0_PROFILE` never refreshed at all, serving whatever token sat
+  on disk. They now refresh like the active profile.
+
+  Static `auth_*` tokens do not expire and are still sent unchanged.

--- a/cmd/dash0/main.go
+++ b/cmd/dash0/main.go
@@ -339,7 +339,7 @@ func main() {
 	// Skip the pre-resolve so `dash0 login --profile <new>` can reach runLogin.
 	skipProfileResolve := targetCmd != nil && (targetCmd.Name() == "login" || targetCmd.Name() == "logout")
 	if selector.IsSet() && !skipProfileResolve {
-		cfg, err := config.ResolveConfigurationForProfile(selector.Name)
+		cfg, err := config.ResolveConfigurationForProfile(ctx, selector.Name)
 		if err != nil {
 			printError(err)
 			os.Exit(1)

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.25.1
 
 require (
 	github.com/cli/browser v1.3.0
-	github.com/dash0hq/dash0-api-client-go v1.20.0
+	github.com/dash0hq/dash0-api-client-go v1.21.0
 	github.com/google/uuid v1.6.0
 	github.com/muesli/termenv v0.16.0
 	github.com/pmezard/go-difflib v1.0.0
@@ -44,6 +44,7 @@ require (
 	github.com/gobwas/glob v0.2.3 // indirect
 	github.com/gofrs/flock v0.13.0 // indirect
 	github.com/golang/snappy v1.0.0 // indirect
+	github.com/google/go-cmp v0.7.0 // indirect
 	github.com/google/go-tpm v0.9.8 // indirect
 	github.com/hashicorp/go-version v1.9.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -11,8 +11,8 @@ github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XL
 github.com/cli/browser v1.3.0 h1:LejqCrpWr+1pRqmEPDGnTZOjsMe7sehifLynZJuqJpo=
 github.com/cli/browser v1.3.0/go.mod h1:HH8s+fOAxjhQoBUAsKuPCbqUuxZDhQ2/aD+SzsEfBTk=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
-github.com/dash0hq/dash0-api-client-go v1.20.0 h1:u0rLjG+Su8qTZvwLu8df+E2QvwXGC83GGihJ8fam+SA=
-github.com/dash0hq/dash0-api-client-go v1.20.0/go.mod h1:KNGbcgETrEN4m2QPGAorZ9FybTpVg/oi20UEoWGCGlE=
+github.com/dash0hq/dash0-api-client-go v1.21.0 h1:O+pghZKfVDmz5Mp1B8o5pYXzLerYd+oklXMu4euqa00=
+github.com/dash0hq/dash0-api-client-go v1.21.0/go.mod h1:+PufWHDFteVN4eG28EDCjnSQF8vUneO92tnEw39SiRY=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -55,7 +55,7 @@ func NewClientFromContext(ctx context.Context, apiUrl, authToken string) (dash0a
 
 	client, err := dash0api.NewClient(
 		dash0api.WithApiUrl(apiUrl),
-		dash0api.WithAuthToken(authToken),
+		authTokenOption(cfg, authToken),
 		dash0api.WithUserAgent(version.UserAgent()),
 		dash0api.WithMaxRetries(maxRetries),
 	)
@@ -106,7 +106,7 @@ func NewOtlpClientFromContext(ctx context.Context, otlpUrl, authToken string) (d
 
 	client, err := dash0api.NewClient(
 		dash0api.WithOtlpEndpoint(dash0api.OtlpEncodingJson, finalOtlpUrl),
-		dash0api.WithAuthToken(finalAuthToken),
+		authTokenOption(cfg, finalAuthToken),
 		dash0api.WithUserAgent(version.UserAgent()),
 		dash0api.WithMaxRetries(maxRetries),
 	)
@@ -170,7 +170,7 @@ func translateConfigError(ctx context.Context, err error) error {
 	if err == nil {
 		return nil
 	}
-	if dash0api.IsOAuthTokenError(err) {
+	if dash0api.IsOAuthTokenError(err) || errors.Is(err, profiles.ErrReauthenticationRequired) {
 		selector := config.ProfileSelectorFromContext(ctx)
 		displayName := selector.Name
 		if agentmode.Enabled {
@@ -205,6 +205,40 @@ func profileNameForUpdate(_ context.Context, displayName string) string {
 		return "<active-profile>"
 	}
 	return active.Name
+}
+
+// oauthShadowed reports whether a static auth token supersedes the profile's
+// OAuth state for this invocation, via DASH0_AUTH_TOKEN or --auth-token. When
+// one does, the static token is used as-is and no refresh is attempted.
+//
+// checkOAuthEmpty and checkOAuthOnOtlp test the same two conditions inline.
+//
+// TODO(dash0-api-client-go #39): once Configuration records each field's source,
+// this and both inline copies collapse into one check.
+func oauthShadowed(cfg *profiles.Configuration, resolvedAuthToken string) bool {
+	if cfg == nil || cfg.OAuth == nil {
+		return false
+	}
+	if os.Getenv(profiles.EnvAuthToken) != "" {
+		return true
+	}
+	// The resolved token differs from what the profile would have supplied, so
+	// it came from a flag override.
+	return resolvedAuthToken != "" && cfg.AuthToken != resolvedAuthToken
+}
+
+// authTokenOption picks how the API client authenticates.
+//
+// An OAuth profile goes through a provider, so the access token is refreshed
+// for as long as the client is in use. An access token is valid for 15 minutes,
+// so a token frozen at construction breaks any command that outlives it.
+// Anything else authenticates with the resolved token directly, because a
+// static auth_* token does not expire.
+func authTokenOption(cfg *profiles.Configuration, resolvedAuthToken string) dash0api.ClientOption {
+	if cfg != nil && cfg.OAuth != nil && !oauthShadowed(cfg, resolvedAuthToken) {
+		return dash0api.WithAuthTokenProvider(cfg.AuthTokenProvider())
+	}
+	return dash0api.WithAuthToken(resolvedAuthToken)
 }
 
 // checkOAuthEmpty surfaces a friendly "not authenticated" error when the

--- a/internal/client/rawhttp.go
+++ b/internal/client/rawhttp.go
@@ -60,6 +60,23 @@ func NewRawHTTPConfig(ctx context.Context, apiUrl, authToken string) (*RawHTTPCo
 	if resolvedApiUrl == "" {
 		return nil, fmt.Errorf("api-url is required; provide it as a flag, environment variable, or configure a profile")
 	}
+
+	// Resolve the token through the profile's provider so an OAuth access token
+	// that is close to (or already past) expiry is refreshed before the request
+	// goes out. The context-carried configuration is not guaranteed to have been
+	// refreshed: the --profile path reads the profile straight off disk.
+	//
+	// One resolution up front is enough here. Raw commands issue a single short
+	// request, unlike the typed client, which consults its provider per request
+	// because it drives multi-page operations.
+	if cfg := profiles.FromContext(ctx); cfg != nil && !oauthShadowed(cfg, resolvedAuthToken) {
+		refreshed, err := cfg.AuthTokenProvider().AuthToken(ctx)
+		if err != nil {
+			return nil, translateConfigError(ctx, err)
+		}
+		resolvedAuthToken = refreshed
+	}
+
 	if resolvedAuthToken == "" {
 		return nil, fmt.Errorf("auth-token is required; provide it as a flag, environment variable, or configure a profile")
 	}

--- a/internal/config/config_cmd.go
+++ b/internal/config/config_cmd.go
@@ -97,7 +97,7 @@ The DASH0_CONFIG_DIR environment variable changes the configuration directory (d
 
 			if profileSelector.IsSet() {
 				profileName = profileSelector.Name
-				resolved, err := ResolveConfigurationForProfile(profileSelector.Name)
+				resolved, err := ResolveConfigurationForProfile(cmd.Context(), profileSelector.Name)
 				if err != nil {
 					return err
 				}

--- a/internal/config/profile_selector.go
+++ b/internal/config/profile_selector.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"sort"
@@ -87,13 +88,24 @@ func ProfileSelectorFromContext(ctx context.Context) ProfileSelector {
 // when no profile with the given name exists.
 // When profileName is empty, callers should use the normal active-profile
 // resolution chain; this function only handles explicit selections.
-func ResolveConfigurationForProfile(profileName string) (*profiles.Configuration, error) {
+//
+// The returned configuration records the profile it came from, which is what
+// lets the client refresh its OAuth access token per request.
+func ResolveConfigurationForProfile(ctx context.Context, profileName string) (*profiles.Configuration, error) {
 	if profileName == "" {
 		return nil, fmt.Errorf("profile name must not be empty")
 	}
 
 	store, err := profiles.NewStore()
 	if err != nil {
+		return nil, err
+	}
+
+	cfg, err := store.GetConfigurationForProfile(ctx, profileName)
+	if err == nil {
+		return cfg, nil
+	}
+	if !errors.Is(err, profiles.ErrProfileNotFound) {
 		return nil, err
 	}
 
@@ -109,38 +121,15 @@ func ResolveConfigurationForProfile(profileName string) (*profiles.Configuration
 		)
 	}
 
-	var matched *profiles.Profile
 	names := make([]string, 0, len(all))
 	for i := range all {
 		names = append(names, all[i].Name)
-		if all[i].Name == profileName {
-			matched = &all[i]
-		}
 	}
 
-	if matched == nil {
-		sort.Strings(names)
-		return nil, fmt.Errorf(
-			"profile %q does not exist. Available profiles: %s",
-			profileName,
-			strings.Join(names, ", "),
-		)
-	}
-
-	cfg := matched.Configuration
-
-	if v := os.Getenv(profiles.EnvApiUrl); v != "" {
-		cfg.ApiUrl = v
-	}
-	if v := os.Getenv(profiles.EnvAuthToken); v != "" {
-		cfg.AuthToken = v
-	}
-	if v := os.Getenv(profiles.EnvOtlpUrl); v != "" {
-		cfg.OtlpUrl = v
-	}
-	if v := os.Getenv(profiles.EnvDataset); v != "" {
-		cfg.Dataset = v
-	}
-
-	return &cfg, nil
+	sort.Strings(names)
+	return nil, fmt.Errorf(
+		"profile %q does not exist. Available profiles: %s",
+		profileName,
+		strings.Join(names, ", "),
+	)
 }

--- a/internal/config/profile_selector_test.go
+++ b/internal/config/profile_selector_test.go
@@ -132,7 +132,7 @@ func TestResolveConfigurationForProfile(t *testing.T) {
 	setActiveProfile(t, configDir, "dev")
 
 	t.Run("selected profile is used", func(t *testing.T) {
-		cfg, err := ResolveConfigurationForProfile("prod")
+		cfg, err := ResolveConfigurationForProfile(context.Background(), "prod")
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -148,7 +148,7 @@ func TestResolveConfigurationForProfile(t *testing.T) {
 		os.Setenv(profiles.EnvDataset, "env-override-ds")
 		defer os.Unsetenv(profiles.EnvDataset)
 
-		cfg, err := ResolveConfigurationForProfile("prod")
+		cfg, err := ResolveConfigurationForProfile(context.Background(), "prod")
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -162,7 +162,7 @@ func TestResolveConfigurationForProfile(t *testing.T) {
 	})
 
 	t.Run("unknown profile returns error listing available profiles", func(t *testing.T) {
-		_, err := ResolveConfigurationForProfile("typo")
+		_, err := ResolveConfigurationForProfile(context.Background(), "typo")
 		if err == nil {
 			t.Fatal("expected error, got nil")
 		}
@@ -176,7 +176,7 @@ func TestResolveConfigurationForProfile(t *testing.T) {
 	})
 
 	t.Run("empty name is rejected", func(t *testing.T) {
-		_, err := ResolveConfigurationForProfile("")
+		_, err := ResolveConfigurationForProfile(context.Background(), "")
 		if err == nil {
 			t.Fatal("expected error for empty name")
 		}
@@ -186,7 +186,7 @@ func TestResolveConfigurationForProfile(t *testing.T) {
 func TestResolveConfigurationForProfile_NoProfilesAtAll(t *testing.T) {
 	_ = setupTestConfigDir(t)
 
-	_, err := ResolveConfigurationForProfile("any")
+	_, err := ResolveConfigurationForProfile(context.Background(), "any")
 	if err == nil {
 		t.Fatal("expected error when no profiles are configured")
 	}

--- a/internal/logging/oauth_refresh_integration_test.go
+++ b/internal/logging/oauth_refresh_integration_test.go
@@ -1,0 +1,339 @@
+//go:build integration
+
+package logging
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/dash0hq/dash0-api-client-go/profiles"
+	"github.com/dash0hq/dash0-cli/internal/agentmode"
+	"github.com/dash0hq/dash0-cli/internal/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// oauthQueryServer is a mock Dash0 API that serves a cursor-paginated log query
+// alongside the OAuth token endpoint, and records the bearer token presented on
+// every page.
+//
+// It exists to pin the behavior reported in #258: a long export must keep
+// working after its 15-minute access token would have expired.
+type oauthQueryServer struct {
+	*httptest.Server
+
+	mu sync.Mutex
+	// bearers records the Authorization header of each /api/logs request, in
+	// order, so a test can assert which token carried which page.
+	bearers []string
+	// tokenCalls counts refresh-grant exchanges.
+	tokenCalls int
+
+	// pages is the number of pages to serve before dropping the cursor.
+	pages int
+	// unauthorizedPage, when positive, makes that 1-based page reply 401 the
+	// first time it is requested.
+	unauthorizedPage int
+	unauthorizedDone bool
+	// refreshStatus and refreshBody override the token endpoint's reply.
+	refreshStatus int
+	refreshBody   map[string]any
+	// issuedTokens is the sequence of access tokens the token endpoint hands
+	// out, in order.
+	issuedTokens []string
+}
+
+func newOAuthQueryServer(t *testing.T, srv *oauthQueryServer) *oauthQueryServer {
+	t.Helper()
+	if srv.pages == 0 {
+		srv.pages = 1
+	}
+	if len(srv.issuedTokens) == 0 {
+		srv.issuedTokens = []string{"dash0_at_refreshed-1", "dash0_at_refreshed-2"}
+	}
+	srv.Server = httptest.NewServer(http.HandlerFunc(srv.handle))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func (s *oauthQueryServer) handle(w http.ResponseWriter, r *http.Request) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if r.URL.Path == "/oauth/token" {
+		s.tokenCalls++
+		if s.refreshStatus != 0 {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(s.refreshStatus)
+			_ = json.NewEncoder(w).Encode(s.refreshBody)
+			return
+		}
+		issued := s.issuedTokens[min(s.tokenCalls-1, len(s.issuedTokens)-1)]
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"access_token":  issued,
+			"refresh_token": fmt.Sprintf("rt-%d", s.tokenCalls),
+			"token_type":    "Bearer",
+			// The real authorization server issues 15-minute access tokens.
+			"expires_in": int64((15 * time.Minute).Seconds()),
+		})
+		return
+	}
+
+	if r.URL.Path != "/api/logs" {
+		w.WriteHeader(http.StatusNotFound)
+		return
+	}
+
+	s.bearers = append(s.bearers, r.Header.Get("Authorization"))
+	page := len(s.bearers)
+
+	if s.unauthorizedPage > 0 && page == s.unauthorizedPage && !s.unauthorizedDone {
+		s.unauthorizedDone = true
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusUnauthorized)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"error": map[string]any{"message": "token expired"},
+		})
+		return
+	}
+
+	// The log-query endpoint replies in OTLP JSON shape, with pagination cursors
+	// alongside the payload.
+	body := map[string]any{
+		"resourceLogs": []any{
+			map[string]any{
+				"resource": map[string]any{
+					"attributes": []any{
+						map[string]any{
+							"key":   "service.name",
+							"value": map[string]any{"stringValue": "my-service"},
+						},
+					},
+				},
+				"scopeLogs": []any{
+					map[string]any{
+						"scope": map[string]any{"name": "dash0-cli"},
+						"logRecords": []any{
+							map[string]any{
+								"timeUnixNano":   "1768471200000000000",
+								"severityNumber": 9,
+								"severityText":   "INFO",
+								"body": map[string]any{
+									"stringValue": fmt.Sprintf("record from page %d", page),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	// Hand out a cursor until the last page, so the CLI keeps paginating.
+	if page < s.pages {
+		body["cursors"] = map[string]any{"after": fmt.Sprintf("cursor-%d", page)}
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(body)
+}
+
+func (s *oauthQueryServer) snapshot() (bearers []string, tokenCalls int) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]string(nil), s.bearers...), s.tokenCalls
+}
+
+// seedOAuthProfile writes an active OAuth profile whose access token is inside
+// the refresh threshold, mirroring the state a CLI invocation finds on disk a
+// few minutes after `dash0 login`.
+func seedOAuthProfile(t *testing.T, apiUrl string, expiresIn time.Duration) {
+	t.Helper()
+	configDir := os.Getenv("DASH0_CONFIG_DIR")
+	require.NotEmpty(t, configDir, "call testutil.SetupTestEnv first")
+
+	profileFile := profiles.ProfilesFile{
+		Profiles: []profiles.Profile{{
+			Name: "oauth-test",
+			Configuration: profiles.Configuration{
+				ApiUrl:    apiUrl,
+				AuthToken: "dash0_at_stale",
+				Dataset:   "default",
+				OAuth: &profiles.OAuthState{
+					ClientID:     "test-client",
+					RefreshToken: "rt-0",
+					ExpiresAt:    time.Now().Add(expiresIn),
+				},
+			},
+		}},
+	}
+	data, err := json.MarshalIndent(profileFile, "", "  ")
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(configDir, profiles.ProfilesFileName), data, 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(configDir, profiles.ActiveProfileFileName), []byte("oauth-test"), 0o600))
+}
+
+// TestQueryLogs_OAuthTokenRefreshedAcrossPages asserts that every page of a
+// paginated export carries a valid token and that walking three pages triggers
+// exactly one refresh-grant exchange, guarding against a per-request refresh
+// storm.
+//
+// Note this test also passes before the fix, because the startup resolution
+// refreshes a token this close to expiry and the whole test then runs inside the
+// new token's validity. Wall-clock expiry mid-run cannot be reproduced in a unit
+// test: the authorization server's floor on expires_in is ten minutes
+// (profiles.OAuthRefreshMinExpiresIn). The two tests that do fail before the fix
+// are TestQueryLogs_OAuthRecoversFromMidQueryUnauthorized below, and
+// TestAuthTransport/asks_the_provider_for_a_token_on_every_request in
+// dash0-api-client-go, which pins the per-request mechanism directly.
+func TestQueryLogs_OAuthTokenRefreshedAcrossPages(t *testing.T) {
+	testutil.SetupTestEnv(t)
+	server := newOAuthQueryServer(t, &oauthQueryServer{pages: 3})
+	// One minute of validity left: inside the five-minute refresh threshold, so
+	// the very first request must already carry a refreshed token.
+	seedOAuthProfile(t, server.URL, 1*time.Minute)
+
+	cmd := newExperimentalLogsCmd()
+	cmd.SetArgs([]string{"logs", "query", "--api-url", server.URL, "--limit", "3"})
+
+	var err error
+	output := testutil.CaptureStdout(t, func() {
+		err = cmd.Execute()
+	})
+	require.NoError(t, err)
+
+	bearers, tokenCalls := server.snapshot()
+	require.Len(t, bearers, 3, "expected the query to walk all three cursor pages")
+	assert.Equal(t, 1, tokenCalls, "expected exactly one refresh-grant exchange")
+	for i, bearer := range bearers {
+		assert.Equal(t, "Bearer dash0_at_refreshed-1", bearer,
+			"page %d carried a stale token; the client must ask its provider per request", i+1)
+		assert.NotContains(t, bearer, "dash0_at_stale", "page %d carried the expiring token", i+1)
+	}
+	assert.Contains(t, output, "record from page 1")
+}
+
+// TestQueryLogs_OAuthRecoversFromMidQueryUnauthorized covers the server
+// rejecting a token the client still considered valid -- clock skew, or a
+// revocation performed elsewhere.
+//
+// TODO: move to the API client, which already covers the replay in
+// TestAuthTransportUnauthorizedRecovery.
+func TestQueryLogs_OAuthRecoversFromMidQueryUnauthorized(t *testing.T) {
+	testutil.SetupTestEnv(t)
+	server := newOAuthQueryServer(t, &oauthQueryServer{
+		pages:            2,
+		unauthorizedPage: 1,
+	})
+	// Plenty of validity left, so nothing is refreshed proactively and the 401
+	// is the only thing that can trigger a refresh.
+	seedOAuthProfile(t, server.URL, 1*time.Hour)
+
+	cmd := newExperimentalLogsCmd()
+	cmd.SetArgs([]string{"logs", "query", "--api-url", server.URL, "--limit", "2"})
+
+	var err error
+	output := testutil.CaptureStdout(t, func() {
+		err = cmd.Execute()
+	})
+	require.NoError(t, err, "the 401 should have been recovered from, not surfaced")
+
+	bearers, tokenCalls := server.snapshot()
+	require.GreaterOrEqual(t, len(bearers), 2, "expected the rejected request to be replayed")
+	assert.Equal(t, "Bearer dash0_at_stale", bearers[0], "the first attempt should use the stored token")
+	assert.Equal(t, "Bearer dash0_at_refreshed-1", bearers[1], "the replay should use a refreshed token")
+	assert.Equal(t, 1, tokenCalls, "expected exactly one forced refresh")
+	assert.Contains(t, output, "record from page")
+}
+
+// TestQueryLogs_OAuthRefreshRejectedMidQuery pins the failure path: when the
+// refresh token is dead the user gets the actionable re-authentication message,
+// a non-zero exit, and no partial output on stdout that a caller could parse as
+// success.
+func TestQueryLogs_OAuthRefreshRejectedMidQuery(t *testing.T) {
+	testutil.SetupTestEnv(t)
+	server := newOAuthQueryServer(t, &oauthQueryServer{
+		pages:         1,
+		refreshStatus: http.StatusBadRequest,
+		refreshBody:   map[string]any{"error": "invalid_grant"},
+	})
+	seedOAuthProfile(t, server.URL, 1*time.Minute)
+
+	cmd := newExperimentalLogsCmd()
+	cmd.SetArgs([]string{"logs", "query", "--api-url", server.URL})
+
+	var err error
+	output := testutil.CaptureStdout(t, func() {
+		err = cmd.Execute()
+	})
+
+	require.Error(t, err, "a dead refresh token must fail the command")
+	assert.Contains(t, err.Error(), "session has expired or was revoked")
+	assert.Contains(t, err.Error(), "dash0 login")
+	assert.Empty(t, output, "no partial output may reach stdout on failure")
+}
+
+// TestQueryLogs_OAuthRefreshRejectedMidQueryAgentMode covers the same failure in
+// agent mode, where `dash0 login` cannot run and the hint must name the
+// static-token escape hatches instead.
+func TestQueryLogs_OAuthRefreshRejectedMidQueryAgentMode(t *testing.T) {
+	testutil.SetupTestEnv(t)
+	// Set the flag directly rather than via agentmode.Init: Init(false) re-runs
+	// agent detection, which leaves the flag set whenever the test itself runs
+	// under an agent, leaking into every later test in the package.
+	prevAgentMode := agentmode.Enabled
+	agentmode.Enabled = true
+	t.Cleanup(func() { agentmode.Enabled = prevAgentMode })
+
+	server := newOAuthQueryServer(t, &oauthQueryServer{
+		pages:         1,
+		refreshStatus: http.StatusBadRequest,
+		refreshBody:   map[string]any{"error": "invalid_grant"},
+	})
+	seedOAuthProfile(t, server.URL, 1*time.Minute)
+
+	cmd := newExperimentalLogsCmd()
+	cmd.SetArgs([]string{"logs", "query", "--api-url", server.URL})
+
+	var err error
+	_ = testutil.CaptureStdout(t, func() {
+		err = cmd.Execute()
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "DASH0_AUTH_TOKEN")
+	assert.NotContains(t, err.Error(), "Run `dash0 login",
+		"agent mode must not point at a command that refuses to run there")
+}
+
+// TestQueryLogs_StaticTokenIsNotRefreshed guards the escape hatch the customer
+// is using as a workaround: a static token must be sent as-is, with no refresh
+// attempt.
+func TestQueryLogs_StaticTokenIsNotRefreshed(t *testing.T) {
+	testutil.SetupTestEnv(t)
+	server := newOAuthQueryServer(t, &oauthQueryServer{pages: 2})
+	seedOAuthProfile(t, server.URL, 1*time.Minute)
+	t.Setenv("DASH0_AUTH_TOKEN", "auth_static-override")
+
+	cmd := newExperimentalLogsCmd()
+	cmd.SetArgs([]string{"logs", "query", "--api-url", server.URL, "--limit", "2"})
+
+	var err error
+	testutil.CaptureStdout(t, func() {
+		err = cmd.Execute()
+	})
+	require.NoError(t, err)
+
+	bearers, tokenCalls := server.snapshot()
+	assert.Equal(t, 0, tokenCalls, "a static token must never trigger a refresh")
+	require.NotEmpty(t, bearers)
+	for i, bearer := range bearers {
+		assert.Equal(t, "Bearer auth_static-override", bearer, "request %d", i+1)
+	}
+}

--- a/internal/query/sampling.go
+++ b/internal/query/sampling.go
@@ -18,14 +18,14 @@ func ParsePrecision(value string, timeRange dash0api.TimeReferenceRange) (*dash0
 	switch strings.ToLower(strings.TrimSpace(value)) {
 	case "":
 		return nil, nil
-	case string(dash0api.Adaptive):
+	case string(dash0api.SamplingModeAdaptive):
 		return &dash0api.Sampling{
-			Mode:      dash0api.Adaptive,
+			Mode:      dash0api.SamplingModeAdaptive,
 			TimeRange: timeRange,
 		}, nil
-	case string(dash0api.Disabled):
+	case string(dash0api.SamplingModeDisabled):
 		return &dash0api.Sampling{
-			Mode:      dash0api.Disabled,
+			Mode:      dash0api.SamplingModeDisabled,
 			TimeRange: timeRange,
 		}, nil
 	default:

--- a/internal/query/sampling_test.go
+++ b/internal/query/sampling_test.go
@@ -27,7 +27,7 @@ func TestParsePrecision(t *testing.T) {
 		s, err := ParsePrecision("adaptive", timeRange)
 		require.NoError(t, err)
 		require.NotNil(t, s)
-		assert.Equal(t, dash0api.Adaptive, s.Mode)
+		assert.Equal(t, dash0api.SamplingModeAdaptive, s.Mode)
 		assert.Equal(t, timeRange, s.TimeRange)
 	})
 
@@ -35,7 +35,7 @@ func TestParsePrecision(t *testing.T) {
 		s, err := ParsePrecision("disabled", timeRange)
 		require.NoError(t, err)
 		require.NotNil(t, s)
-		assert.Equal(t, dash0api.Disabled, s.Mode)
+		assert.Equal(t, dash0api.SamplingModeDisabled, s.Mode)
 		assert.Equal(t, timeRange, s.TimeRange)
 	})
 
@@ -43,7 +43,7 @@ func TestParsePrecision(t *testing.T) {
 		s, err := ParsePrecision("DISABLED", timeRange)
 		require.NoError(t, err)
 		require.NotNil(t, s)
-		assert.Equal(t, dash0api.Disabled, s.Mode)
+		assert.Equal(t, dash0api.SamplingModeDisabled, s.Mode)
 	})
 
 	t.Run("invalid value returns an error", func(t *testing.T) {

--- a/internal/tracing/traces_get.go
+++ b/internal/tracing/traces_get.go
@@ -207,7 +207,7 @@ func runGet(cmd *cobra.Command, traceID string, flags *getFlags) error {
 	}
 
 	sampling := &dash0api.Sampling{
-		Mode:      dash0api.Disabled,
+		Mode:      dash0api.SamplingModeDisabled,
 		TimeRange: timeRange,
 	}
 
@@ -229,7 +229,7 @@ func runGet(cmd *cobra.Command, traceID string, flags *getFlags) error {
 			To:   "now",
 		}
 		followSampling := &dash0api.Sampling{
-			Mode:      dash0api.Disabled,
+			Mode:      dash0api.SamplingModeDisabled,
 			TimeRange: followTimeRange,
 		}
 

--- a/internal/tracing/traces_integration_test.go
+++ b/internal/tracing/traces_integration_test.go
@@ -174,7 +174,7 @@ func TestGetTrace_AlwaysSendsPrecisionDisabled(t *testing.T) {
 	var req dash0api.GetSpansRequest
 	require.NoError(t, json.Unmarshal(last.Body, &req))
 	require.NotNil(t, req.Sampling, "traces get must always set the sampling field")
-	assert.Equal(t, dash0api.Disabled, req.Sampling.Mode)
+	assert.Equal(t, dash0api.SamplingModeDisabled, req.Sampling.Mode)
 }
 
 func TestGetTrace_BackwardCompatWithExperimentalFlag(t *testing.T) {

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -43,7 +43,7 @@ buildGoModule (finalAttrs: {
   # replaced with the real hash: build once, then copy the `got: sha256-...`
   # value from the resulting hash-mismatch error into this field. Re-run after
   # any change to go.mod / go.sum. See the README's "Install with Nix" section.
-  vendorHash = "sha256-GJzLrYvUMVPK/PfLtDTKnMti/96S5J2XVMUk06cdMQo=";
+  vendorHash = "sha256-ty202l2IRpKc4wKZqXBHNRP8RdbsccWlmfUsJl3wfR8=";
 
   # Only the CLI entrypoint is a `main` package; building it explicitly avoids
   # compiling test-only helpers into the output.


### PR DESCRIPTION
Fixes #258

## Problem

Two bugs, one root cause. OAuth access tokens live 15 minutes.

1. The token is resolved once at startup and frozen into the client, so long commands fail partway through with `authentication failed; check your auth token (status: 401)`. This hits large `logs query` exports, bulk `apply -f`, and `list` over many assets.
2. `--profile <name>` and `DASH0_PROFILE` never refreshed at all. `ResolveConfigurationForProfile` hand-rolled `GetProfiles` plus a search by name, so it served whatever token was stored on disk and failed as soon as that token was over 15 minutes old. Only the active-profile path refreshed.

## Solution

Build the client from a refreshing token provider instead of a token string, and resolve named profiles through the profiles package rather than by hand.
