### PR TITLE
fix(client): retry a 409 dataset version conflict instead of failing immediately

### DIFF
--- a/.chloggen/fix_concurrent-spam-filter-apply.yaml
+++ b/.chloggen/fix_concurrent-spam-filter-apply.yaml
@@ -1,0 +1,30 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern (e.g. dashboards, config, apply)
+component: apply
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Retry a 409 dataset version conflict instead of failing immediately when creating or updating dashboards, check rules, views, recording rules, synthetic checks, or spam filters"
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [261]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  Two `dash0` processes (e.g. a CI matrix, or a script running concurrent `apply`/`create`/`update`
+  commands) writing to the same dataset at once could previously race the dataset's optimistic-concurrency
+  version check: the losing write got a 409 that nothing retried, and surfaced as a fatal error. The losing
+  write is now retried with backoff, up to the existing `--max-retries`/`DASH0_MAX_RETRIES` budget.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with "chore" or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Default: '[user]'
+change_logs: []

--- a/internal/asset/checkrule.go
+++ b/internal/asset/checkrule.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	dash0api "github.com/dash0hq/dash0-api-client-go"
+	"github.com/dash0hq/dash0-cli/internal/client"
 )
 
 // ImportCheckRule creates or updates a check rule via the standard CRUD APIs.
@@ -26,13 +27,12 @@ func ImportCheckRule(ctx context.Context, apiClient dash0api.Client, rule *dash0
 		}
 	}
 
-	var result *dash0api.PrometheusAlertRule
-	var err error
-	if id != "" {
-		result, err = apiClient.UpdateCheckRule(ctx, id, rule, dataset)
-	} else {
-		result, err = apiClient.CreateCheckRule(ctx, rule, dataset)
-	}
+	result, err := client.RetryOnConflict(ctx, func() (*dash0api.PrometheusAlertRule, error) {
+		if id != "" {
+			return apiClient.UpdateCheckRule(ctx, id, rule, dataset)
+		}
+		return apiClient.CreateCheckRule(ctx, rule, dataset)
+	})
 	if err != nil {
 		return ImportResult{}, err
 	}
@@ -42,4 +42,3 @@ func ImportCheckRule(ctx context.Context, apiClient dash0api.Client, rule *dash0
 	}
 	return ImportResult{Name: result.Name, ID: id, Action: action, Before: before, After: result}, nil
 }
-

--- a/internal/asset/dashboard.go
+++ b/internal/asset/dashboard.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	dash0api "github.com/dash0hq/dash0-api-client-go"
+	"github.com/dash0hq/dash0-cli/internal/client"
 )
 
 // ImportDashboard creates or updates a dashboard via the standard CRUD APIs.
@@ -28,14 +29,13 @@ func ImportDashboard(ctx context.Context, apiClient dash0api.Client, dashboard *
 		}
 	}
 
-	var result *dash0api.DashboardDefinition
-	var err error
-	if id != "" {
-		dash0api.ClearDashboardID(dashboard)
-		result, err = apiClient.UpdateDashboard(ctx, id, dashboard, dataset)
-	} else {
-		result, err = apiClient.CreateDashboard(ctx, dashboard, dataset)
-	}
+	result, err := client.RetryOnConflict(ctx, func() (*dash0api.DashboardDefinition, error) {
+		if id != "" {
+			dash0api.ClearDashboardID(dashboard)
+			return apiClient.UpdateDashboard(ctx, id, dashboard, dataset)
+		}
+		return apiClient.CreateDashboard(ctx, dashboard, dataset)
+	})
 	if err != nil {
 		return ImportResult{}, err
 	}
@@ -51,4 +51,3 @@ func ImportDashboard(ctx context.Context, apiClient dash0api.Client, dashboard *
 	}
 	return ImportResult{Name: name, ID: id, Action: action, Before: before, After: result}, nil
 }
-

--- a/internal/asset/recordingrule.go
+++ b/internal/asset/recordingrule.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	dash0api "github.com/dash0hq/dash0-api-client-go"
+	"github.com/dash0hq/dash0-cli/internal/client"
 )
 
 const labelVersion = "dash0.com/version"
@@ -98,13 +99,12 @@ func ImportRecordingRule(ctx context.Context, apiClient dash0api.Client, rule *d
 		CarryRecordingRuleVersion(before.(*dash0api.RecordingRule), rule)
 	}
 
-	var result *dash0api.RecordingRule
-	var err error
-	if id != "" {
-		result, err = apiClient.UpdateRecordingRule(ctx, id, rule, dataset)
-	} else {
-		result, err = apiClient.CreateRecordingRule(ctx, rule, dataset)
-	}
+	result, err := client.RetryOnConflict(ctx, func() (*dash0api.RecordingRule, error) {
+		if id != "" {
+			return apiClient.UpdateRecordingRule(ctx, id, rule, dataset)
+		}
+		return apiClient.CreateRecordingRule(ctx, rule, dataset)
+	})
 	if err != nil {
 		return ImportResult{}, err
 	}

--- a/internal/asset/spamfilter.go
+++ b/internal/asset/spamfilter.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	dash0api "github.com/dash0hq/dash0-api-client-go"
+	"github.com/dash0hq/dash0-cli/internal/client"
 	sigsyaml "sigs.k8s.io/yaml"
 )
 
@@ -100,13 +101,12 @@ func ImportSpamFilter(ctx context.Context, apiClient dash0api.Client, filter *da
 		}
 	}
 
-	var result *dash0api.SpamFilter
-	var err error
-	if upsertKey != "" {
-		result, err = apiClient.UpdateSpamFilter(ctx, upsertKey, filter, dataset)
-	} else {
-		result, err = apiClient.CreateSpamFilter(ctx, filter, dataset)
-	}
+	result, err := client.RetryOnConflict(ctx, func() (*dash0api.SpamFilter, error) {
+		if upsertKey != "" {
+			return apiClient.UpdateSpamFilter(ctx, upsertKey, filter, dataset)
+		}
+		return apiClient.CreateSpamFilter(ctx, filter, dataset)
+	})
 	if err != nil {
 		return ImportResult{}, err
 	}
@@ -142,13 +142,12 @@ func ImportSpamFilterV1Alpha2(ctx context.Context, apiClient dash0api.Client, fi
 		}
 	}
 
-	var result *dash0api.SpamFilterV1Alpha2
-	var err error
-	if upsertKey != "" {
-		result, err = apiClient.UpdateSpamFilterV1Alpha2(ctx, upsertKey, filter, dataset)
-	} else {
-		result, err = apiClient.CreateSpamFilterV1Alpha2(ctx, filter, dataset)
-	}
+	result, err := client.RetryOnConflict(ctx, func() (*dash0api.SpamFilterV1Alpha2, error) {
+		if upsertKey != "" {
+			return apiClient.UpdateSpamFilterV1Alpha2(ctx, upsertKey, filter, dataset)
+		}
+		return apiClient.CreateSpamFilterV1Alpha2(ctx, filter, dataset)
+	})
 	if err != nil {
 		return ImportResult{}, err
 	}

--- a/internal/asset/syntheticcheck.go
+++ b/internal/asset/syntheticcheck.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	dash0api "github.com/dash0hq/dash0-api-client-go"
+	"github.com/dash0hq/dash0-cli/internal/client"
 )
 
 // ImportSyntheticCheck creates or updates a synthetic check via the standard CRUD APIs.
@@ -26,13 +27,12 @@ func ImportSyntheticCheck(ctx context.Context, apiClient dash0api.Client, check 
 		}
 	}
 
-	var result *dash0api.SyntheticCheckDefinition
-	var err error
-	if id != "" {
-		result, err = apiClient.UpdateSyntheticCheck(ctx, id, check, dataset)
-	} else {
-		result, err = apiClient.CreateSyntheticCheck(ctx, check, dataset)
-	}
+	result, err := client.RetryOnConflict(ctx, func() (*dash0api.SyntheticCheckDefinition, error) {
+		if id != "" {
+			return apiClient.UpdateSyntheticCheck(ctx, id, check, dataset)
+		}
+		return apiClient.CreateSyntheticCheck(ctx, check, dataset)
+	})
 	if err != nil {
 		return ImportResult{}, err
 	}

--- a/internal/asset/view.go
+++ b/internal/asset/view.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	dash0api "github.com/dash0hq/dash0-api-client-go"
+	"github.com/dash0hq/dash0-cli/internal/client"
 )
 
 // ImportView creates or updates a view via the standard CRUD APIs.
@@ -26,13 +27,12 @@ func ImportView(ctx context.Context, apiClient dash0api.Client, view *dash0api.V
 		}
 	}
 
-	var result *dash0api.ViewDefinition
-	var err error
-	if id != "" {
-		result, err = apiClient.UpdateView(ctx, id, view, dataset)
-	} else {
-		result, err = apiClient.CreateView(ctx, view, dataset)
-	}
+	result, err := client.RetryOnConflict(ctx, func() (*dash0api.ViewDefinition, error) {
+		if id != "" {
+			return apiClient.UpdateView(ctx, id, view, dataset)
+		}
+		return apiClient.CreateView(ctx, view, dataset)
+	})
 	if err != nil {
 		return ImportResult{}, err
 	}

--- a/internal/client/retry_conflict.go
+++ b/internal/client/retry_conflict.go
@@ -1,0 +1,92 @@
+package client
+
+import (
+	"context"
+	"math/rand"
+	"time"
+
+	dash0api "github.com/dash0hq/dash0-api-client-go"
+)
+
+const (
+	// conflictRetryWaitMin is the starting point for the exponential backoff
+	// between dataset-version-conflict retries. It is shorter than the general
+	// request retry transport's 500ms floor because a dataset-version race is
+	// expected to resolve almost immediately — the other writer, not a rate
+	// limiter or an overloaded server, is what is being waited on.
+	conflictRetryWaitMin = 100 * time.Millisecond
+	// conflictRetryWaitMax caps the backoff between retries.
+	conflictRetryWaitMax = 2 * time.Second
+)
+
+// conflictRetryWait pauses for d, honoring context cancellation. Tests
+// override this so retry backoff does not slow down the suite.
+var conflictRetryWait = func(ctx context.Context, d time.Duration) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-time.After(d):
+		return nil
+	}
+}
+
+// RetryOnConflict runs fn and retries it while it fails with a 409 dataset
+// version conflict (dash0api.IsConflict), up to the --max-retries /
+// DASH0_MAX_RETRIES budget (see resolveMaxRetries), with jittered exponential
+// backoff between attempts.
+//
+// A Dash0 dataset is guarded by an optimistic-concurrency "dataset version":
+// two writes to the same dataset that race one another leave exactly one
+// winner, and the loser gets a 409 whose message literally says "please
+// retry". Nothing below this call retries that: the api-client-go transport's
+// own retry logic covers only 429 and 5xx (see shouldRetry in that module's
+// transport.go). Every dataset-scoped asset write (dashboards, check rules,
+// views, recording rules, synthetic checks, spam filters, notification
+// channels, teams) must go through here instead of calling the API client
+// directly, so a losing write converges on retry instead of surfacing as a
+// fatal error.
+//
+// This retries the CLI's own losing write; it does not prevent the race
+// itself, and it does not need to — the dash0 CLI has no intra-process
+// concurrency in its asset-write paths (apply applies documents from a single
+// sequential loop, and no other command parallelizes writes), so the only way
+// this race occurs is across separate `dash0` process invocations: a CI
+// matrix, or a script/agent running concurrent `apply`/`create`/`update`
+// commands against the same dataset. An in-process lock (the fix used in the
+// Terraform provider, which does have intra-process concurrency via
+// Terraform's own parallel resource graph) would not address that. See
+// https://github.com/dash0hq/dash0-cli/issues/261.
+func RetryOnConflict[T any](ctx context.Context, fn func() (T, error)) (T, error) {
+	maxRetries, err := resolveMaxRetries(ctx)
+	if err != nil {
+		// --max-retries/DASH0_MAX_RETRIES was already validated once when the
+		// API client was constructed for this invocation; a failure here would
+		// mean that validation regressed. Fail safe by not retrying at all
+		// rather than looping on a config error.
+		maxRetries = 0
+	}
+
+	var result T
+	for attempt := 0; ; attempt++ {
+		result, err = fn()
+		if err == nil || !dash0api.IsConflict(err) || attempt >= maxRetries {
+			return result, err
+		}
+		if waitErr := conflictRetryWait(ctx, conflictBackoff(attempt)); waitErr != nil {
+			return result, waitErr
+		}
+	}
+}
+
+// conflictBackoff returns a jittered backoff for the given (0-based) retry
+// attempt: full jitter (a random duration in [0, cap]) over an exponential
+// cap that doubles from conflictRetryWaitMin and saturates at
+// conflictRetryWaitMax. Full jitter spreads out retries from multiple racing
+// CLI processes so they do not all wake up and collide again at once.
+func conflictBackoff(attempt int) time.Duration {
+	ceiling := conflictRetryWaitMin * time.Duration(1<<attempt)
+	if ceiling <= 0 || ceiling > conflictRetryWaitMax {
+		ceiling = conflictRetryWaitMax
+	}
+	return time.Duration(rand.Int63n(int64(ceiling)))
+}

--- a/internal/client/retry_conflict_test.go
+++ b/internal/client/retry_conflict_test.go
@@ -1,0 +1,158 @@
+package client
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	dash0api "github.com/dash0hq/dash0-api-client-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func conflictErr() error {
+	return &dash0api.APIError{StatusCode: http.StatusConflict, Message: "dataset version conflict, please retry"}
+}
+
+// withNoConflictBackoff makes RetryOnConflict retry instantly during tests,
+// so the suite is not slowed down by the real (jittered, up to 2s) backoff.
+func withNoConflictBackoff(t *testing.T) {
+	t.Helper()
+	previous := conflictRetryWait
+	conflictRetryWait = func(ctx context.Context, d time.Duration) error {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+			return nil
+		}
+	}
+	t.Cleanup(func() { conflictRetryWait = previous })
+}
+
+func TestRetryOnConflict_SucceedsFirstTry(t *testing.T) {
+	withNoConflictBackoff(t)
+
+	calls := 0
+	result, err := RetryOnConflict(context.Background(), func() (string, error) {
+		calls++
+		return "ok", nil
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, "ok", result)
+	assert.Equal(t, 1, calls)
+}
+
+func TestRetryOnConflict_RetriesUntilItLandsWithinBudget(t *testing.T) {
+	withNoConflictBackoff(t)
+
+	calls := 0
+	result, err := RetryOnConflict(context.Background(), func() (string, error) {
+		calls++
+		if calls <= DefaultMaxRetries {
+			// Fail with 409 on every attempt up to (and including) the last
+			// retry, then succeed on the final allowed attempt.
+			return "", conflictErr()
+		}
+		return "won", nil
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, "won", result)
+	assert.Equal(t, DefaultMaxRetries+1, calls)
+}
+
+func TestRetryOnConflict_GivesUpAfterMaxRetriesExhausted(t *testing.T) {
+	withNoConflictBackoff(t)
+
+	calls := 0
+	_, err := RetryOnConflict(context.Background(), func() (string, error) {
+		calls++
+		return "", conflictErr()
+	})
+
+	require.Error(t, err)
+	assert.True(t, dash0api.IsConflict(err))
+	// One initial attempt plus DefaultMaxRetries retries, never more:
+	// a persistent conflict must still surface as an error eventually.
+	assert.Equal(t, DefaultMaxRetries+1, calls)
+}
+
+func TestRetryOnConflict_DoesNotRetryNonConflictErrors(t *testing.T) {
+	withNoConflictBackoff(t)
+
+	calls := 0
+	wantErr := errors.New("boom")
+	_, err := RetryOnConflict(context.Background(), func() (string, error) {
+		calls++
+		return "", wantErr
+	})
+
+	require.ErrorIs(t, err, wantErr)
+	assert.Equal(t, 1, calls, "a non-409 error must not be retried")
+}
+
+func TestRetryOnConflict_HonorsContextCancellation(t *testing.T) {
+	// Deliberately do NOT stub conflictRetryWait here: we want the real
+	// implementation's select-on-ctx.Done() behavior under test.
+	ctx, cancel := context.WithCancel(context.Background())
+
+	calls := 0
+	result, err := RetryOnConflict(ctx, func() (string, error) {
+		calls++
+		if calls == 1 {
+			cancel()
+		}
+		return "", conflictErr()
+	})
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, "", result)
+	assert.Equal(t, 1, calls, "must stop retrying once the context is canceled")
+}
+
+func TestRetryOnConflict_RespectsMaxRetriesFromContext(t *testing.T) {
+	withNoConflictBackoff(t)
+
+	n := 1
+	ctx := WithMaxRetries(context.Background(), &n)
+
+	calls := 0
+	_, err := RetryOnConflict(ctx, func() (string, error) {
+		calls++
+		return "", conflictErr()
+	})
+
+	require.Error(t, err)
+	assert.Equal(t, 2, calls, "1 initial attempt + 1 retry from the --max-retries override")
+}
+
+func TestConflictBackoff_NeverExceedsCapAndGrows(t *testing.T) {
+	for attempt := range 8 {
+		for range 20 {
+			d := conflictBackoff(attempt)
+			if d < 0 || d > conflictRetryWaitMax {
+				t.Fatalf("attempt %d: backoff %v out of bounds [0, %v]", attempt, d, conflictRetryWaitMax)
+			}
+		}
+	}
+}
+
+func TestRetryOnConflict_PropagatesNonErrorResultOnFinalFailure(t *testing.T) {
+	withNoConflictBackoff(t)
+
+	// Even when every attempt fails, the zero value of T (not a stale
+	// previous success) must come back with the error.
+	result, err := RetryOnConflict(context.Background(), func() (int, error) {
+		return 0, fmt.Errorf("wrapped: %w", conflictErr())
+	})
+
+	require.Error(t, err)
+	assert.True(t, dash0api.IsConflict(err))
+	assert.Equal(t, 0, result)
+}

--- a/test/roundtrip/fixtures/check-rule.yaml
+++ b/test/roundtrip/fixtures/check-rule.yaml
@@ -12,4 +12,6 @@ labels:
   should_not_count: "true"
 name: Error logs from Minecraft server
 summary: Error logs from Minecraft server
-thresholds: {}
+thresholds:
+  degraded: 1
+  failed: 5

--- a/test/roundtrip/run_all.sh
+++ b/test/roundtrip/run_all.sh
@@ -76,6 +76,7 @@ API_TESTS=(
   "${SCRIPT_DIR}/test_notification_channel_roundtrip.sh"
   "${SCRIPT_DIR}/test_spam_filter_roundtrip.sh"
   "${SCRIPT_DIR}/test_spam_filter_v1alpha2_roundtrip.sh"
+  "${SCRIPT_DIR}/test_spam_filter_concurrent_create.sh"
   "${SCRIPT_DIR}/test_team_roundtrip.sh"
   "${SCRIPT_DIR}/test_team_declarative_roundtrip.sh"
 )

--- a/test/roundtrip/test_spam_filter_concurrent_create.sh
+++ b/test/roundtrip/test_spam_filter_concurrent_create.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Regression test for https://github.com/dash0hq/dash0-cli/issues/261:
+# concurrent `dash0` CLI invocations creating/updating dataset-scoped assets
+# in the same dataset used to race the dataset's optimistic-concurrency
+# "dataset version" and fail with an unretried 409 for all but one writer.
+# The fix retries a 409 dataset version conflict with backoff instead of
+# surfacing it immediately (see internal/client/retry_conflict.go).
+#
+# Unlike the Terraform provider's version of this bug, the dash0 CLI has no
+# intra-process concurrency in its asset-write paths — `apply` applies
+# documents from a single sequential loop — so this test reproduces the race
+# the way it actually occurs for the CLI: multiple separate `dash0` process
+# invocations writing the same dataset at once (e.g. a CI matrix, or a
+# script/agent running several `create`/`apply` commands concurrently).
+#
+# Steps:
+#   1. Launch FILTER_COUNT concurrent `dash0 spam-filters create` processes
+#      against the same dataset, each with a unique origin.
+#   2. Assert every process exited 0 — before the fix, all but (usually)
+#      one exited non-zero with an unretried 409.
+#   3. Verify all FILTER_COUNT filters exist via the CLI.
+#   4. Clean up by deleting each one.
+
+export DASH0_AGENT_MODE=0
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DASH0="${SCRIPT_DIR}/../../build/dash0"
+FIXTURES="${SCRIPT_DIR}/fixtures"
+FIXTURE="${FIXTURES}/spam-filter.yaml"
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR"' EXIT
+
+# Comfortably enough concurrent writers to make the race the common case
+# rather than a lucky non-collision.
+FILTER_COUNT=8
+
+echo "=== Spam filter concurrent create test ==="
+echo "Filter count: ${FILTER_COUNT}"
+
+declare -a ORIGINS
+for i in $(seq 1 "$FILTER_COUNT"); do
+  origin="concurrent-create-$(printf '%02d' "$i")-$(uuidgen | tr '[:upper:]' '[:lower:]')"
+  ORIGINS+=("$origin")
+  yaml_file="${TMPDIR}/filter-${i}.yaml"
+  ORIGIN="$origin" yq '.metadata.labels."dash0.com/origin" = env(ORIGIN)' "$FIXTURE" > "$yaml_file"
+done
+
+echo "--- Step 1: Launching ${FILTER_COUNT} concurrent 'spam-filters create' processes ---"
+declare -a PIDS
+for i in $(seq 1 "$FILTER_COUNT"); do
+  "$DASH0" -X spam-filters create -f "${TMPDIR}/filter-${i}.yaml" \
+    > "${TMPDIR}/out-${i}.log" 2>&1 &
+  PIDS+=($!)
+done
+
+echo "--- Step 2: Waiting for all processes and checking exit codes ---"
+FAILED=0
+for i in $(seq 1 "$FILTER_COUNT"); do
+  pid="${PIDS[$((i - 1))]}"
+  if ! wait "$pid"; then
+    echo "FAIL: concurrent create #${i} (origin ${ORIGINS[$((i - 1))]}) exited non-zero:"
+    cat "${TMPDIR}/out-${i}.log"
+    FAILED=$((FAILED + 1))
+  else
+    echo "  #${i} (origin ${ORIGINS[$((i - 1))]}): OK"
+  fi
+done
+
+if [ "$FAILED" -gt 0 ]; then
+  echo "FAIL: ${FAILED}/${FILTER_COUNT} concurrent creates failed — likely the unretried 409 dataset version conflict from issue #261."
+  # Best-effort cleanup of whichever ones did succeed.
+  for origin in "${ORIGINS[@]}"; do
+    "$DASH0" -X spam-filters delete "$origin" --force > /dev/null 2>&1 || true
+  done
+  exit 1
+fi
+
+echo "All ${FILTER_COUNT} concurrent creates converged in a single run."
+
+echo "--- Step 3: Verifying all ${FILTER_COUNT} filters exist via the CLI ---"
+LIST_JSON=$("$DASH0" -X spam-filters list --all -o json)
+for origin in "${ORIGINS[@]}"; do
+  count=$(echo "$LIST_JSON" | jq --arg o "$origin" '[.[] | select(.metadata.labels["dash0.com/origin"] == $o)] | length')
+  if [ "$count" != "1" ]; then
+    echo "FAIL: expected exactly 1 record with origin '$origin', got $count"
+    exit 1
+  fi
+done
+echo "All ${FILTER_COUNT} filters verified."
+
+echo "--- Step 4: Cleaning up ---"
+CLEANUP_FAILED=0
+for origin in "${ORIGINS[@]}"; do
+  if ! "$DASH0" -X spam-filters delete "$origin" --force > /dev/null; then
+    echo "FAIL: cleanup delete failed for origin '$origin'"
+    CLEANUP_FAILED=1
+  fi
+done
+if [ "$CLEANUP_FAILED" -ne 0 ]; then
+  exit 1
+fi
+
+echo "=== Spam filter concurrent create test PASSED ==="


### PR DESCRIPTION
Fixes #261.

Two `dash0` CLI processes (e.g. a CI matrix, or a script/agent running concurrent `apply`/`create`/`update` commands) writing to the same dataset at once could race the dataset's optimistic-concurrency "dataset version" check. The losing write got a 409 that nothing in the stack retried, and it surfaced as a fatal CLI error instead of converging.

- `internal/client/retry_conflict.go` adds `RetryOnConflict[T]`, retrying a write while it returns a 409 (`dash0api.IsConflict`), up to the existing `--max-retries`/`DASH0_MAX_RETRIES` budget, with jittered exponential backoff (100ms–2s) honoring context cancellation.
- Wired into every dataset-scoped asset's write path: `ImportDashboard`, `ImportCheckRule`, `ImportView`, `ImportRecordingRule`, `ImportSyntheticCheck`, `ImportSpamFilter`/`ImportSpamFilterV1Alpha2` — covering both `apply` and the per-asset `create`/`update` commands, since they share this code.
- Notification channels and teams are untouched: they're organization-level, not dataset-scoped, so they aren't documented as sharing this version model.

Note on scope: unlike the Terraform provider's version of this bug (fixed with an in-process per-dataset mutex, since Terraform's own parallel resource graph issues concurrent writes from goroutines inside one `terraform apply`), the `dash0` CLI has no intra-process concurrency in its asset-write paths — `apply` applies documents from a single sequential loop. The race here is exclusively cross-process, so a mutex would not have addressed it; retry-with-backoff does.