### PR TITLE
chore(roundtrip): set real thresholds in the check-rule fixture

### DIFF
--- a/test/roundtrip/fixtures/check-rule.yaml
+++ b/test/roundtrip/fixtures/check-rule.yaml
@@ -12,4 +12,6 @@ labels:
   should_not_count: "true"
 name: Error logs from Minecraft server
 summary: Error logs from Minecraft server
-thresholds: {}
+thresholds:
+  degraded: 1
+  failed: 5


### PR DESCRIPTION
## Summary

`test/roundtrip/fixtures/check-rule.yaml` uses an expression referencing `$__threshold` but declared `thresholds: {}` (empty). The Dash0 API now rejects that combination for an enabled rule:

```
Bad Request: The submitted check rule uses $__threshold in its expression but defines no thresholds. Set at
least one of thresholds.degraded or thresholds.failed, or the dash0-threshold-degraded /
dash0-threshold-critical annotation on the rule.
```

This breaks `test_check_rule_roundtrip.sh` and `test_apply_check_rule_idempotency.sh` in CI — confirmed pre-existing on `main` (same two jobs fail on the latest `main` CI run), unrelated to any pending PR.

Fix: set `thresholds: {degraded: 1, failed: 5}` on the fixture.

Left `test_apply_notification_channel_assets_warning.sh`'s inline check rule alone — it has the same `$__threshold`/empty-thresholds shape but stays `enabled: false`, and the server does not validate thresholds on a disabled rule (which is why that test currently passes).

Out of scope: `test_log_roundtrip` and `test_span_roundtrip` are also currently red on `main`, but with an unrelated live-data-timing flake ("log record not found after 6 attempts"), not a fixture problem.