### PR TITLE
fix(nix): pass version and date to the package from overlays.default

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -70,7 +70,13 @@
       # Overlay so downstreams can pull `dash0` into their own nixpkgs instance:
       #   nixpkgs.overlays = [ dash0-cli.overlays.default ];
       overlays.default = final: _prev: {
-        dash0 = final.callPackage ./nix/package.nix { };
+        # `inherit version date` rather than an empty argument set: without it
+        # the package falls back to the placeholder defaults in
+        # nix/package.nix, so the overlay and packages.<system>.dash0 become
+        # two different derivations of the same source. A config that uses
+        # both this overlay and homeManagerModules.default then builds the CLI
+        # twice per rebuild, under two different version strings.
+        dash0 = final.callPackage ./nix/package.nix { inherit version date; };
       };
 
       # Home Manager module for declarative per-user profiles:

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -9,8 +9,15 @@
   installShellFiles,
   stdenv,
   # Build metadata. `flake.nix` overrides these with values derived from the
-  # flake source; the defaults keep a bare `nix-build ./nix/package.nix` working.
-  version ? "1.15.0",
+  # flake source; the defaults keep a bare `nix-build ./nix/package.nix` (and
+  # default.nix) working.
+  #
+  # The version default is a placeholder rather than a real release number on
+  # purpose. Nothing keeps it in step with the version in flake.nix, so any
+  # real number here goes stale at the next release and then silently mislabels
+  # every caller that does not pass one -- which is how the overlay ended up
+  # shipping a "1.15.0" build of 1.16.5 source.
+  version ? "0.0.0-dev",
   date ? "1970-01-01T00:00:00Z",
 }:
 


### PR DESCRIPTION
Fixes #272.

## What was wrong

`overlays.default` called the package with an empty argument set:

```nix
overlays.default = final: _prev: {
  dash0 = final.callPackage ./nix/package.nix { };
};
```

so `version` and `date` fell back to the defaults in `nix/package.nix`, while `packages.<system>.dash0` was passed the real values. The two entry points were different derivations of the same source. A configuration using **both** this overlay and `homeManagerModules.default` — whose `package` option defaults to `packages.<system>.dash0` — compiled the CLI twice per rebuild, once labelled `1.15.0` and once `1.16.5`, and reported whichever one the caller happened to reach:

```
$ /run/current-system/sw/bin/dash0 version   # overlay
dash0 version 1.15.0
$ dash0 version                              # Home Manager module
dash0 version 1.16.5 (built on 2026-08-24T17:24:37Z)
```

Both values are already in scope where the overlay is defined, so passing them is the whole fix.

## The second change, and why

The version fallback goes from `"1.15.0"` to `"0.0.0-dev"`.

The defaults are there so a bare `nix-build ./nix/package.nix` and `default.nix` keep working, and they should stay. But nothing keeps a real version number there in step with `flake.nix`, so it goes stale at the next release and then silently mislabels every caller that does not pass one — which is exactly how the `1.15.0` build above came about. Bumping it to `1.16.5` would only reset the clock. A placeholder cannot go stale, and `nix-build` output that says `0.0.0-dev` is honest rather than wrong.

Happy to drop this half if you would rather bump the number, or to wire both `flake.nix` and the default to a single `nix/version.nix` instead — that removes the drift properly, at the cost of one more file in a version that already lives in `CHANGELOG.md`, `flake.nix`, and `Formula/dash0.rb`.